### PR TITLE
Mark prerelease tags as GitHub prereleases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,5 +26,8 @@ archives:
 checksum:
   name_template: checksums.txt
 
+release:
+  prerelease: auto
+
 changelog:
   use: git

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ When `AUDIT_SIGNING_KEY` is unset, audit entries omit the `signature` field rath
 ## Install
 
 Official release archives are published for `darwin` and `linux` on `amd64` and `arm64`.
+Tags with prerelease identifiers such as `-rc.1` or `-beta.1` are published as GitHub prereleases automatically.
 
 Replace `VERSION` with the release tag you want to install.
 

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -22,6 +22,7 @@
 - [ ] Validate release config: `goreleaser check`.
 - [ ] Validate snapshot archives and checksums: `goreleaser release --snapshot --clean`.
 - [ ] Confirm GitHub Release contains `darwin` and `linux` archives for `amd64` and `arm64`, plus `checksums.txt`.
+- [ ] Confirm prerelease tags such as `v0.1.0-rc.1` are published as GitHub prereleases.
 - [ ] Verify server startup and MCP tool listing with target client.
 - [ ] Confirm audit event format includes actor, reason, scope, timestamp, and outcome.
 - [ ] Confirm runbook owners for provider outage and credential rotation.


### PR DESCRIPTION
## Summary

- configure GoReleaser to mark semver prerelease tags such as `v0.1.0-rc.2` as GitHub prereleases automatically
- document prerelease tag behavior in the install docs and release checklist

## Validation

- `./bin/goreleaser check`
- created and pushed tag `v0.1.0-rc.2`
- verified release workflow succeeded: https://github.com/keithdoyle9/pipeline-mcp/actions/runs/22779984938
- verified published release is marked as a prerelease: https://github.com/keithdoyle9/pipeline-mcp/releases/tag/v0.1.0-rc.2
