### PR TITLE
docs: update README prerelease install example

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,10 +78,10 @@ For least-privilege token setup and release operations, see [docs/operator-guide
 Official release archives are published for `darwin` and `linux` on `amd64` and `arm64`.
 Tags with prerelease identifiers such as `-rc.1` or `-beta.1` are published as GitHub prereleases automatically.
 
-Replace `VERSION` with the release tag you want to install.
+Current prerelease example:
 
 ```bash
-VERSION=v0.2.0
+VERSION=v0.1.0-rc.1
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
 ARCH="$(uname -m)"
 


### PR DESCRIPTION
## Summary
- update the README install example to use the published `v0.1.0-rc.1` prerelease
- replace the placeholder version language with a concrete prerelease example

## Validation
- verified release archive download, checksum validation, extract, and executable install for `v0.1.0-rc.1`
- verified `go install github.com/keithdoyle9/pipeline-mcp/cmd/pipeline-mcp@latest` resolves to `v0.1.0-rc.1`
- smoke tested Claude Code MCP registration against the released binary
