### PR TITLE
Slice 13: add provider abstraction seam

### DIFF
--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -15,6 +15,7 @@ import (
 	"github.com/keithdoyle9/pipeline-mcp/internal/analysis"
 	"github.com/keithdoyle9/pipeline-mcp/internal/domain"
 	"github.com/keithdoyle9/pipeline-mcp/internal/githubapi"
+	"github.com/keithdoyle9/pipeline-mcp/internal/providers"
 	"github.com/keithdoyle9/pipeline-mcp/internal/service"
 	"github.com/keithdoyle9/pipeline-mcp/internal/telemetry"
 )
@@ -151,7 +152,7 @@ func evaluateFixture(fixture caseFixture) (benchmarkCaseResult, error) {
 	}
 	svc := service.New(
 		cfg,
-		benchmarkGitHubClient{fixture: fixture},
+		githubapi.NewProviderAdapter(benchmarkGitHubClient{fixture: fixture}, cfg.GitHubAPIBaseURL),
 		noopAuditStore{},
 		telemetry.NewCollector(""),
 		slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -214,7 +215,7 @@ func topCategoriesForFixture(fixture caseFixture, diagnostic *domain.FailureDiag
 	}
 
 	categories := make([]string, 0, 3)
-	for _, candidate := range analysis.RankFailureDiagnoses(fixture.Logs, fixture.Jobs) {
+	for _, candidate := range analysis.RankFailureDiagnoses(fixture.Logs, providerJobsFromGitHub(fixture.Jobs)) {
 		categories = append(categories, candidate.FailureCategory)
 		if len(categories) == 3 {
 			break
@@ -224,6 +225,25 @@ func topCategoriesForFixture(fixture caseFixture, diagnostic *domain.FailureDiag
 		return []string{diagnostic.FailureCategory}
 	}
 	return categories
+}
+
+func providerJobsFromGitHub(jobs []githubapi.Job) []providers.Job {
+	out := make([]providers.Job, 0, len(jobs))
+	for _, job := range jobs {
+		out = append(out, providers.Job{
+			ID:          job.ID,
+			Name:        job.Name,
+			Status:      job.Status,
+			Conclusion:  job.Conclusion,
+			HeadBranch:  job.HeadBranch,
+			StartedAt:   job.StartedAt,
+			CompletedAt: job.CompletedAt,
+			RunURL:      job.HTMLURL,
+			CheckRunURL: job.CheckRunURL,
+			RunnerID:    job.RunnerID,
+		})
+	}
+	return out
 }
 
 func containsCategory(categories []string, want string) bool {

--- a/cmd/pipeline-mcp/main.go
+++ b/cmd/pipeline-mcp/main.go
@@ -36,8 +36,9 @@ func run() error {
 
 	telemetryCollector := telemetry.NewCollector(cfg.MetricsExportPath)
 	ghClient := githubapi.NewClient(cfg.GitHubAPIBaseURL, cfg.GitHubReadToken, cfg.GitHubWriteToken, cfg.UserAgent, cfg.HTTPTimeout)
+	ghProvider := githubapi.NewProviderAdapter(ghClient, cfg.GitHubAPIBaseURL)
 	auditStore := audit.NewJSONLStore(cfg.AuditLogPath, cfg.AuditSigningKey)
-	svc := service.New(cfg, ghClient, auditStore, telemetryCollector, logger)
+	svc := service.New(cfg, ghProvider, auditStore, telemetryCollector, logger)
 
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    cfg.ServerName,

--- a/internal/analysis/diagnosis.go
+++ b/internal/analysis/diagnosis.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/keithdoyle9/pipeline-mcp/internal/domain"
-	"github.com/keithdoyle9/pipeline-mcp/internal/githubapi"
+	"github.com/keithdoyle9/pipeline-mcp/internal/providers"
 )
 
 type categoryRule struct {
@@ -99,12 +99,12 @@ var diagnosisRules = []categoryRule{
 	},
 }
 
-func RankFailureDiagnoses(logs string, jobs []githubapi.Job) []RankedDiagnosis {
+func RankFailureDiagnoses(logs string, jobs []providers.Job) []RankedDiagnosis {
 	ranked, _ := rankFailureDiagnoses(logs, jobs)
 	return ranked
 }
 
-func rankFailureDiagnoses(logs string, jobs []githubapi.Job) ([]RankedDiagnosis, []string) {
+func rankFailureDiagnoses(logs string, jobs []providers.Job) ([]RankedDiagnosis, []string) {
 	logs = RedactSecrets(logs)
 	impactedJobs := failedJobs(jobs)
 
@@ -156,7 +156,7 @@ func rankFailureDiagnoses(logs string, jobs []githubapi.Job) ([]RankedDiagnosis,
 	return ranked, impactedJobs
 }
 
-func DiagnoseFailure(logs string, jobs []githubapi.Job) (domain.FailureDiagnostic, []domain.FixRecommendation) {
+func DiagnoseFailure(logs string, jobs []providers.Job) (domain.FailureDiagnostic, []domain.FixRecommendation) {
 	ranked, impactedJobs := rankFailureDiagnoses(logs, jobs)
 	if len(ranked) == 0 {
 		ranked = []RankedDiagnosis{unknownRankedDiagnosis(RedactSecrets(logs), impactedJobs)}
@@ -172,7 +172,7 @@ func DiagnoseFailure(logs string, jobs []githubapi.Job) (domain.FailureDiagnosti
 	}, best.Recommendations
 }
 
-func failedJobs(jobs []githubapi.Job) []string {
+func failedJobs(jobs []providers.Job) []string {
 	out := make([]string, 0, len(jobs))
 	for _, job := range jobs {
 		if strings.EqualFold(job.Conclusion, "failure") || strings.EqualFold(job.Status, "failed") {

--- a/internal/analysis/diagnosis_test.go
+++ b/internal/analysis/diagnosis_test.go
@@ -4,12 +4,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/keithdoyle9/pipeline-mcp/internal/githubapi"
+	"github.com/keithdoyle9/pipeline-mcp/internal/providers"
 )
 
 func TestDiagnoseFailureTestCategory(t *testing.T) {
 	logs := "--- FAIL: TestCheckout\nAssertionError: expected 200 got 500"
-	jobs := []githubapi.Job{{Name: "test", Conclusion: "failure"}}
+	jobs := []providers.Job{{Name: "test", Conclusion: "failure"}}
 
 	diagnostic, recommendations := DiagnoseFailure(logs, jobs)
 	if diagnostic.FailureCategory != "test_failure" {
@@ -44,7 +44,7 @@ func TestRankFailureDiagnosesOrdersCategoriesByScore(t *testing.T) {
 		"step timed out",
 	}, "\n")
 
-	ranked := RankFailureDiagnoses(logs, []githubapi.Job{{Name: "test", Conclusion: "failure"}})
+	ranked := RankFailureDiagnoses(logs, []providers.Job{{Name: "test", Conclusion: "failure"}})
 	if len(ranked) < 3 {
 		t.Fatalf("expected at least 3 ranked diagnoses, got %d", len(ranked))
 	}

--- a/internal/analysis/flaky.go
+++ b/internal/analysis/flaky.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/keithdoyle9/pipeline-mcp/internal/domain"
-	"github.com/keithdoyle9/pipeline-mcp/internal/githubapi"
+	"github.com/keithdoyle9/pipeline-mcp/internal/providers"
 )
 
 var testNamePatterns = []*regexp.Regexp{
@@ -27,7 +27,7 @@ type flakyAggregate struct {
 func AnalyzeFlakyTests(
 	repository, workflow string,
 	lookbackDays int,
-	runs []githubapi.WorkflowRun,
+	runs []providers.Run,
 	fetchLogs LogFetcher,
 	now time.Time,
 ) domain.FlakyTestReport {

--- a/internal/analysis/flaky_test.go
+++ b/internal/analysis/flaky_test.go
@@ -5,12 +5,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/keithdoyle9/pipeline-mcp/internal/githubapi"
+	"github.com/keithdoyle9/pipeline-mcp/internal/providers"
 )
 
 func TestAnalyzeFlakyTests(t *testing.T) {
 	now := time.Date(2026, 3, 6, 12, 0, 0, 0, time.UTC)
-	runs := []githubapi.WorkflowRun{
+	runs := []providers.Run{
 		{ID: 1, Conclusion: "failure", UpdatedAt: now.Add(-2 * time.Hour)},
 		{ID: 2, Conclusion: "failure", UpdatedAt: now.Add(-1 * time.Hour)},
 		{ID: 3, Conclusion: "success", UpdatedAt: now.Add(-30 * time.Minute)},

--- a/internal/analysis/performance.go
+++ b/internal/analysis/performance.go
@@ -6,10 +6,10 @@ import (
 	"time"
 
 	"github.com/keithdoyle9/pipeline-mcp/internal/domain"
-	"github.com/keithdoyle9/pipeline-mcp/internal/githubapi"
+	"github.com/keithdoyle9/pipeline-mcp/internal/providers"
 )
 
-func BuildPerformanceSnapshot(repository, workflow string, from, to time.Time, currentRuns, baselineRuns []githubapi.WorkflowRun) domain.PipelinePerformanceSnapshot {
+func BuildPerformanceSnapshot(repository, workflow string, from, to time.Time, currentRuns, baselineRuns []providers.Run) domain.PipelinePerformanceSnapshot {
 	current := calculateWindowMetrics(currentRuns)
 	baseline := calculateWindowMetrics(baselineRuns)
 
@@ -29,7 +29,7 @@ func BuildPerformanceSnapshot(repository, workflow string, from, to time.Time, c
 	}
 }
 
-func calculateWindowMetrics(runs []githubapi.WorkflowRun) domain.WindowMetrics {
+func calculateWindowMetrics(runs []providers.Run) domain.WindowMetrics {
 	if len(runs) == 0 {
 		return domain.WindowMetrics{FailureBreakdown: map[string]int{}}
 	}
@@ -83,7 +83,7 @@ func calculateWindowMetrics(runs []githubapi.WorkflowRun) domain.WindowMetrics {
 	}
 }
 
-func runDurationMS(run githubapi.WorkflowRun) int64 {
+func runDurationMS(run providers.Run) int64 {
 	end := run.UpdatedAt
 	start := run.CreatedAt
 	if run.RunStartedAt != nil && !run.RunStartedAt.IsZero() {
@@ -95,7 +95,7 @@ func runDurationMS(run githubapi.WorkflowRun) int64 {
 	return end.Sub(start).Milliseconds()
 }
 
-func queueTimeMS(run githubapi.WorkflowRun) int64 {
+func queueTimeMS(run providers.Run) int64 {
 	if run.RunStartedAt == nil || run.RunStartedAt.IsZero() {
 		return 0
 	}
@@ -105,7 +105,7 @@ func queueTimeMS(run githubapi.WorkflowRun) int64 {
 	return run.RunStartedAt.Sub(run.CreatedAt).Milliseconds()
 }
 
-func classifyRunFailure(run githubapi.WorkflowRun) string {
+func classifyRunFailure(run providers.Run) string {
 	conclusion := strings.ToLower(strings.TrimSpace(run.Conclusion))
 	switch conclusion {
 	case "timed_out", "cancelled":

--- a/internal/githubapi/adapter.go
+++ b/internal/githubapi/adapter.go
@@ -37,8 +37,12 @@ func (a *ProviderAdapter) ProviderID() string {
 	return domain.ProviderGitHub
 }
 
-func (a *ProviderAdapter) ParseRepository(repository string) (owner string, repo string, err error) {
-	return ParseRepository(repository)
+func (a *ProviderAdapter) ParseRepository(repository string) (string, error) {
+	owner, repo, err := ParseRepository(repository)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s/%s", owner, repo), nil
 }
 
 func (a *ProviderAdapter) ParseRunURL(raw string) (*providers.RunLocator, error) {
@@ -47,10 +51,9 @@ func (a *ProviderAdapter) ParseRunURL(raw string) (*providers.RunLocator, error)
 		return nil, err
 	}
 	return &providers.RunLocator{
-		Owner:  locator.Owner,
-		Repo:   locator.Repo,
-		RunID:  locator.RunID,
-		RunURL: locator.RunURL,
+		Repository: locator.Repository(),
+		RunID:      locator.RunID,
+		RunURL:     locator.RunURL,
 	}, nil
 }
 
@@ -61,11 +64,19 @@ func (a *ProviderAdapter) ParseCheckRunURL(raw string) (int64, error) {
 	return ParseCheckRunURLForBase(raw, a.apiBaseURL)
 }
 
-func (a *ProviderAdapter) RunURL(owner, repo string, runID int64) string {
+func (a *ProviderAdapter) RunURL(repository string, runID int64) string {
+	owner, repo, err := ParseRepository(repository)
+	if err != nil {
+		return ""
+	}
 	return fmt.Sprintf("https://github.com/%s/%s/actions/runs/%d", owner, repo, runID)
 }
 
-func (a *ProviderAdapter) GetRun(ctx context.Context, owner, repo string, runID int64) (*providers.Run, error) {
+func (a *ProviderAdapter) GetRun(ctx context.Context, repository string, runID int64) (*providers.Run, error) {
+	owner, repo, err := a.ownerRepo(repository)
+	if err != nil {
+		return nil, err
+	}
 	run, err := a.client.GetRun(ctx, owner, repo, runID)
 	if err != nil || run == nil {
 		return nil, err
@@ -73,7 +84,11 @@ func (a *ProviderAdapter) GetRun(ctx context.Context, owner, repo string, runID 
 	return toProviderRun(run), nil
 }
 
-func (a *ProviderAdapter) ListRunJobs(ctx context.Context, owner, repo string, runID int64) ([]providers.Job, error) {
+func (a *ProviderAdapter) ListRunJobs(ctx context.Context, repository string, runID int64) ([]providers.Job, error) {
+	owner, repo, err := a.ownerRepo(repository)
+	if err != nil {
+		return nil, err
+	}
 	jobs, err := a.client.ListRunJobs(ctx, owner, repo, runID)
 	if err != nil {
 		return nil, err
@@ -81,11 +96,19 @@ func (a *ProviderAdapter) ListRunJobs(ctx context.Context, owner, repo string, r
 	return toProviderJobs(jobs), nil
 }
 
-func (a *ProviderAdapter) DownloadRunLogs(ctx context.Context, owner, repo string, runID int64, maxBytes int64) (string, error) {
+func (a *ProviderAdapter) DownloadRunLogs(ctx context.Context, repository string, runID int64, maxBytes int64) (string, error) {
+	owner, repo, err := a.ownerRepo(repository)
+	if err != nil {
+		return "", err
+	}
 	return a.client.DownloadRunLogs(ctx, owner, repo, runID, maxBytes)
 }
 
-func (a *ProviderAdapter) ListRepositoryRuns(ctx context.Context, owner, repo string, opts providers.ListRunsOptions, maxRuns int) ([]providers.Run, error) {
+func (a *ProviderAdapter) ListRepositoryRuns(ctx context.Context, repository string, opts providers.ListRunsOptions, maxRuns int) ([]providers.Run, error) {
+	owner, repo, err := a.ownerRepo(repository)
+	if err != nil {
+		return nil, err
+	}
 	runs, err := a.client.ListRepositoryRuns(ctx, owner, repo, ListRunsOptions{
 		PerPage: opts.PerPage,
 		Page:    opts.Page,
@@ -100,7 +123,11 @@ func (a *ProviderAdapter) ListRepositoryRuns(ctx context.Context, owner, repo st
 	return toProviderRuns(runs), nil
 }
 
-func (a *ProviderAdapter) GetCheckRun(ctx context.Context, owner, repo string, checkRunID int64) (*providers.CheckRun, error) {
+func (a *ProviderAdapter) GetCheckRun(ctx context.Context, repository string, checkRunID int64) (*providers.CheckRun, error) {
+	owner, repo, err := a.ownerRepo(repository)
+	if err != nil {
+		return nil, err
+	}
 	checkRun, err := a.client.GetCheckRun(ctx, owner, repo, checkRunID)
 	if err != nil || checkRun == nil {
 		return nil, err
@@ -108,7 +135,11 @@ func (a *ProviderAdapter) GetCheckRun(ctx context.Context, owner, repo string, c
 	return toProviderCheckRun(checkRun), nil
 }
 
-func (a *ProviderAdapter) GetCheckRunAnnotations(ctx context.Context, owner, repo string, checkRunID int64) ([]providers.CheckRunAnnotation, error) {
+func (a *ProviderAdapter) GetCheckRunAnnotations(ctx context.Context, repository string, checkRunID int64) ([]providers.CheckRunAnnotation, error) {
+	owner, repo, err := a.ownerRepo(repository)
+	if err != nil {
+		return nil, err
+	}
 	annotations, err := a.client.GetCheckRunAnnotations(ctx, owner, repo, checkRunID)
 	if err != nil {
 		return nil, err
@@ -116,7 +147,11 @@ func (a *ProviderAdapter) GetCheckRunAnnotations(ctx context.Context, owner, rep
 	return toProviderAnnotations(annotations), nil
 }
 
-func (a *ProviderAdapter) ListDeploymentBranchPolicies(ctx context.Context, owner, repo, environment string) ([]providers.BranchPolicy, error) {
+func (a *ProviderAdapter) ListDeploymentBranchPolicies(ctx context.Context, repository, environment string) ([]providers.BranchPolicy, error) {
+	owner, repo, err := a.ownerRepo(repository)
+	if err != nil {
+		return nil, err
+	}
 	policies, err := a.client.ListDeploymentBranchPolicies(ctx, owner, repo, environment)
 	if err != nil {
 		return nil, err
@@ -124,7 +159,11 @@ func (a *ProviderAdapter) ListDeploymentBranchPolicies(ctx context.Context, owne
 	return toProviderPolicies(policies), nil
 }
 
-func (a *ProviderAdapter) Rerun(ctx context.Context, owner, repo string, runID int64, failedJobsOnly bool) error {
+func (a *ProviderAdapter) Rerun(ctx context.Context, repository string, runID int64, failedJobsOnly bool) error {
+	owner, repo, err := a.ownerRepo(repository)
+	if err != nil {
+		return err
+	}
 	return a.client.Rerun(ctx, owner, repo, runID, failedJobsOnly)
 }
 
@@ -158,6 +197,10 @@ func (a *ProviderAdapter) MapError(err error) *domain.ToolError {
 		return domain.NewToolError(domain.ErrorCodeProviderUnavailable, "GitHub API is unavailable.", "Retry with exponential backoff and check provider status.", true, map[string]any{"error": err.Error()})
 	}
 	return domain.NewToolError(domain.ErrorCodeInternal, "Unexpected internal error.", "Check server logs and retry.", true, map[string]any{"error": err.Error()})
+}
+
+func (a *ProviderAdapter) ownerRepo(repository string) (string, string, error) {
+	return ParseRepository(repository)
 }
 
 func toProviderRun(run *WorkflowRun) *providers.Run {

--- a/internal/githubapi/adapter.go
+++ b/internal/githubapi/adapter.go
@@ -1,0 +1,292 @@
+package githubapi
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/keithdoyle9/pipeline-mcp/internal/domain"
+	"github.com/keithdoyle9/pipeline-mcp/internal/providers"
+)
+
+type providerClient interface {
+	GetRun(ctx context.Context, owner, repo string, runID int64) (*WorkflowRun, error)
+	ListRunJobs(ctx context.Context, owner, repo string, runID int64) ([]Job, error)
+	DownloadRunLogs(ctx context.Context, owner, repo string, runID int64, maxBytes int64) (string, error)
+	ListRepositoryRuns(ctx context.Context, owner, repo string, opts ListRunsOptions, maxRuns int) ([]WorkflowRun, error)
+	GetCheckRun(ctx context.Context, owner, repo string, checkRunID int64) (*CheckRun, error)
+	GetCheckRunAnnotations(ctx context.Context, owner, repo string, checkRunID int64) ([]CheckRunAnnotation, error)
+	ListDeploymentBranchPolicies(ctx context.Context, owner, repo, environment string) ([]BranchPolicy, error)
+	Rerun(ctx context.Context, owner, repo string, runID int64, failedJobsOnly bool) error
+}
+
+type ProviderAdapter struct {
+	client     providerClient
+	apiBaseURL string
+}
+
+func NewProviderAdapter(client providerClient, apiBaseURL string) *ProviderAdapter {
+	return &ProviderAdapter{
+		client:     client,
+		apiBaseURL: strings.TrimRight(strings.TrimSpace(apiBaseURL), "/"),
+	}
+}
+
+func (a *ProviderAdapter) ProviderID() string {
+	return domain.ProviderGitHub
+}
+
+func (a *ProviderAdapter) ParseRepository(repository string) (owner string, repo string, err error) {
+	return ParseRepository(repository)
+}
+
+func (a *ProviderAdapter) ParseRunURL(raw string) (*providers.RunLocator, error) {
+	locator, err := ParseRunURL(raw)
+	if err != nil {
+		return nil, err
+	}
+	return &providers.RunLocator{
+		Owner:  locator.Owner,
+		Repo:   locator.Repo,
+		RunID:  locator.RunID,
+		RunURL: locator.RunURL,
+	}, nil
+}
+
+func (a *ProviderAdapter) ParseCheckRunURL(raw string) (int64, error) {
+	if strings.TrimSpace(a.apiBaseURL) == "" {
+		return ParseCheckRunURL(raw)
+	}
+	return ParseCheckRunURLForBase(raw, a.apiBaseURL)
+}
+
+func (a *ProviderAdapter) RunURL(owner, repo string, runID int64) string {
+	return fmt.Sprintf("https://github.com/%s/%s/actions/runs/%d", owner, repo, runID)
+}
+
+func (a *ProviderAdapter) GetRun(ctx context.Context, owner, repo string, runID int64) (*providers.Run, error) {
+	run, err := a.client.GetRun(ctx, owner, repo, runID)
+	if err != nil || run == nil {
+		return nil, err
+	}
+	return toProviderRun(run), nil
+}
+
+func (a *ProviderAdapter) ListRunJobs(ctx context.Context, owner, repo string, runID int64) ([]providers.Job, error) {
+	jobs, err := a.client.ListRunJobs(ctx, owner, repo, runID)
+	if err != nil {
+		return nil, err
+	}
+	return toProviderJobs(jobs), nil
+}
+
+func (a *ProviderAdapter) DownloadRunLogs(ctx context.Context, owner, repo string, runID int64, maxBytes int64) (string, error) {
+	return a.client.DownloadRunLogs(ctx, owner, repo, runID, maxBytes)
+}
+
+func (a *ProviderAdapter) ListRepositoryRuns(ctx context.Context, owner, repo string, opts providers.ListRunsOptions, maxRuns int) ([]providers.Run, error) {
+	runs, err := a.client.ListRepositoryRuns(ctx, owner, repo, ListRunsOptions{
+		PerPage: opts.PerPage,
+		Page:    opts.Page,
+		Created: opts.Created,
+		Branch:  opts.Branch,
+		Event:   opts.Event,
+		Status:  opts.Status,
+	}, maxRuns)
+	if err != nil {
+		return nil, err
+	}
+	return toProviderRuns(runs), nil
+}
+
+func (a *ProviderAdapter) GetCheckRun(ctx context.Context, owner, repo string, checkRunID int64) (*providers.CheckRun, error) {
+	checkRun, err := a.client.GetCheckRun(ctx, owner, repo, checkRunID)
+	if err != nil || checkRun == nil {
+		return nil, err
+	}
+	return toProviderCheckRun(checkRun), nil
+}
+
+func (a *ProviderAdapter) GetCheckRunAnnotations(ctx context.Context, owner, repo string, checkRunID int64) ([]providers.CheckRunAnnotation, error) {
+	annotations, err := a.client.GetCheckRunAnnotations(ctx, owner, repo, checkRunID)
+	if err != nil {
+		return nil, err
+	}
+	return toProviderAnnotations(annotations), nil
+}
+
+func (a *ProviderAdapter) ListDeploymentBranchPolicies(ctx context.Context, owner, repo, environment string) ([]providers.BranchPolicy, error) {
+	policies, err := a.client.ListDeploymentBranchPolicies(ctx, owner, repo, environment)
+	if err != nil {
+		return nil, err
+	}
+	return toProviderPolicies(policies), nil
+}
+
+func (a *ProviderAdapter) Rerun(ctx context.Context, owner, repo string, runID int64, failedJobsOnly bool) error {
+	return a.client.Rerun(ctx, owner, repo, runID, failedJobsOnly)
+}
+
+func (a *ProviderAdapter) IsLogsUnavailable(err error) bool {
+	return errors.Is(err, ErrLogsUnavailable)
+}
+
+func (a *ProviderAdapter) MapError(err error) *domain.ToolError {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, ErrUnauthorized) || errors.Is(err, ErrWriteTokenRequired) {
+		return domain.NewToolError(domain.ErrorCodeUnauthorized, "GitHub API authorization failed.", "Verify token scopes: actions:read for read tools and actions:write for rerun.", false, map[string]any{"error": err.Error()})
+	}
+	if errors.Is(err, ErrNotFound) {
+		return domain.NewToolError(
+			domain.ErrorCodeUnauthorized,
+			"Run not found or access denied.",
+			"Confirm the run URL is correct and provide a token that can read this repository. For Claude Code, add the server with -e GITHUB_READ_TOKEN=... or -e GITHUB_TOKEN=....",
+			false,
+			map[string]any{"error": err.Error()},
+		)
+	}
+	if errors.Is(err, ErrRateLimited) {
+		return domain.NewToolError(domain.ErrorCodeRateLimited, "GitHub API rate limit exceeded.", "Retry after backoff or increase API quota/token capacity.", true, map[string]any{"error": err.Error()})
+	}
+	if errors.Is(err, ErrLogsUnavailable) {
+		return domain.NewToolError(domain.ErrorCodeLogUnavailable, "Run logs are unavailable.", "Check repository permissions and log retention settings.", true, map[string]any{"error": err.Error()})
+	}
+	if errors.Is(err, ErrProviderUnavailable) {
+		return domain.NewToolError(domain.ErrorCodeProviderUnavailable, "GitHub API is unavailable.", "Retry with exponential backoff and check provider status.", true, map[string]any{"error": err.Error()})
+	}
+	return domain.NewToolError(domain.ErrorCodeInternal, "Unexpected internal error.", "Check server logs and retry.", true, map[string]any{"error": err.Error()})
+}
+
+func toProviderRun(run *WorkflowRun) *providers.Run {
+	if run == nil {
+		return nil
+	}
+	return &providers.Run{
+		ID:           run.ID,
+		Name:         run.Name,
+		DisplayTitle: run.DisplayTitle,
+		Status:       run.Status,
+		Conclusion:   run.Conclusion,
+		RunURL:       run.HTMLURL,
+		HeadSHA:      run.HeadSHA,
+		CreatedAt:    run.CreatedAt,
+		UpdatedAt:    run.UpdatedAt,
+		RunStartedAt: run.RunStartedAt,
+	}
+}
+
+func toProviderRuns(runs []WorkflowRun) []providers.Run {
+	out := make([]providers.Run, 0, len(runs))
+	for _, run := range runs {
+		out = append(out, providers.Run{
+			ID:           run.ID,
+			Name:         run.Name,
+			DisplayTitle: run.DisplayTitle,
+			Status:       run.Status,
+			Conclusion:   run.Conclusion,
+			RunURL:       run.HTMLURL,
+			HeadSHA:      run.HeadSHA,
+			CreatedAt:    run.CreatedAt,
+			UpdatedAt:    run.UpdatedAt,
+			RunStartedAt: run.RunStartedAt,
+		})
+	}
+	return out
+}
+
+func toProviderJobs(jobs []Job) []providers.Job {
+	out := make([]providers.Job, 0, len(jobs))
+	for _, job := range jobs {
+		out = append(out, providers.Job{
+			ID:          job.ID,
+			Name:        job.Name,
+			Status:      job.Status,
+			Conclusion:  job.Conclusion,
+			HeadBranch:  job.HeadBranch,
+			StartedAt:   job.StartedAt,
+			CompletedAt: job.CompletedAt,
+			RunURL:      job.HTMLURL,
+			CheckRunURL: job.CheckRunURL,
+			RunnerID:    job.RunnerID,
+			Steps:       toProviderSteps(job.Steps),
+		})
+	}
+	return out
+}
+
+func toProviderSteps(steps []Step) []providers.Step {
+	out := make([]providers.Step, 0, len(steps))
+	for _, step := range steps {
+		out = append(out, providers.Step{
+			Name:        step.Name,
+			Status:      step.Status,
+			Conclusion:  step.Conclusion,
+			Number:      step.Number,
+			StartedAt:   step.StartedAt,
+			CompletedAt: step.CompletedAt,
+		})
+	}
+	return out
+}
+
+func toProviderCheckRun(checkRun *CheckRun) *providers.CheckRun {
+	if checkRun == nil {
+		return nil
+	}
+	return &providers.CheckRun{
+		ID:         checkRun.ID,
+		Name:       checkRun.Name,
+		RunURL:     checkRun.HTMLURL,
+		DetailsURL: checkRun.DetailsURL,
+		Status:     checkRun.Status,
+		Conclusion: checkRun.Conclusion,
+		Output: providers.CheckRunOutput{
+			Title:          checkRun.Output.Title,
+			Summary:        checkRun.Output.Summary,
+			Text:           checkRun.Output.Text,
+			AnnotationsURL: checkRun.Output.AnnotationsURL,
+		},
+		Deployment: toProviderDeployment(checkRun.Deployment),
+	}
+}
+
+func toProviderDeployment(deployment *DeploymentInfo) *providers.DeploymentInfo {
+	if deployment == nil {
+		return nil
+	}
+	return &providers.DeploymentInfo{
+		ID:                  deployment.ID,
+		Environment:         deployment.Environment,
+		OriginalEnvironment: deployment.OriginalEnvironment,
+	}
+}
+
+func toProviderAnnotations(annotations []CheckRunAnnotation) []providers.CheckRunAnnotation {
+	out := make([]providers.CheckRunAnnotation, 0, len(annotations))
+	for _, annotation := range annotations {
+		out = append(out, providers.CheckRunAnnotation{
+			Path:            annotation.Path,
+			StartLine:       annotation.StartLine,
+			AnnotationLevel: annotation.AnnotationLevel,
+			Title:           annotation.Title,
+			Message:         annotation.Message,
+			BlobHref:        annotation.BlobHref,
+		})
+	}
+	return out
+}
+
+func toProviderPolicies(policies []BranchPolicy) []providers.BranchPolicy {
+	out := make([]providers.BranchPolicy, 0, len(policies))
+	for _, policy := range policies {
+		out = append(out, providers.BranchPolicy{
+			ID:   policy.ID,
+			Name: policy.Name,
+			Type: policy.Type,
+		})
+	}
+	return out
+}

--- a/internal/providers/types.go
+++ b/internal/providers/types.go
@@ -1,0 +1,122 @@
+package providers
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/keithdoyle9/pipeline-mcp/internal/domain"
+)
+
+type Adapter interface {
+	ProviderID() string
+	ParseRepository(repository string) (owner string, repo string, err error)
+	ParseRunURL(raw string) (*RunLocator, error)
+	ParseCheckRunURL(raw string) (int64, error)
+	RunURL(owner, repo string, runID int64) string
+	GetRun(ctx context.Context, owner, repo string, runID int64) (*Run, error)
+	ListRunJobs(ctx context.Context, owner, repo string, runID int64) ([]Job, error)
+	DownloadRunLogs(ctx context.Context, owner, repo string, runID int64, maxBytes int64) (string, error)
+	ListRepositoryRuns(ctx context.Context, owner, repo string, opts ListRunsOptions, maxRuns int) ([]Run, error)
+	GetCheckRun(ctx context.Context, owner, repo string, checkRunID int64) (*CheckRun, error)
+	GetCheckRunAnnotations(ctx context.Context, owner, repo string, checkRunID int64) ([]CheckRunAnnotation, error)
+	ListDeploymentBranchPolicies(ctx context.Context, owner, repo, environment string) ([]BranchPolicy, error)
+	Rerun(ctx context.Context, owner, repo string, runID int64, failedJobsOnly bool) error
+	IsLogsUnavailable(err error) bool
+	MapError(err error) *domain.ToolError
+}
+
+type RunLocator struct {
+	Owner  string
+	Repo   string
+	RunID  int64
+	RunURL string
+}
+
+func (r RunLocator) Repository() string {
+	return fmt.Sprintf("%s/%s", r.Owner, r.Repo)
+}
+
+type Run struct {
+	ID           int64
+	Name         string
+	DisplayTitle string
+	Status       string
+	Conclusion   string
+	RunURL       string
+	HeadSHA      string
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
+	RunStartedAt *time.Time
+}
+
+type Step struct {
+	Name        string
+	Status      string
+	Conclusion  string
+	Number      int
+	StartedAt   *time.Time
+	CompletedAt *time.Time
+}
+
+type Job struct {
+	ID          int64
+	Name        string
+	Status      string
+	Conclusion  string
+	HeadBranch  string
+	StartedAt   *time.Time
+	CompletedAt *time.Time
+	RunURL      string
+	CheckRunURL string
+	RunnerID    int64
+	Steps       []Step
+}
+
+type ListRunsOptions struct {
+	PerPage int
+	Page    int
+	Created string
+	Branch  string
+	Event   string
+	Status  string
+}
+
+type CheckRun struct {
+	ID         int64
+	Name       string
+	RunURL     string
+	DetailsURL string
+	Status     string
+	Conclusion string
+	Output     CheckRunOutput
+	Deployment *DeploymentInfo
+}
+
+type CheckRunOutput struct {
+	Title          *string
+	Summary        *string
+	Text           *string
+	AnnotationsURL string
+}
+
+type DeploymentInfo struct {
+	ID                  int64
+	Environment         string
+	OriginalEnvironment string
+}
+
+type CheckRunAnnotation struct {
+	Path            string
+	StartLine       int
+	AnnotationLevel string
+	Title           string
+	Message         string
+	BlobHref        string
+}
+
+type BranchPolicy struct {
+	ID   int64
+	Name string
+	Type string
+}

--- a/internal/providers/types.go
+++ b/internal/providers/types.go
@@ -2,7 +2,6 @@ package providers
 
 import (
 	"context"
-	"fmt"
 	"time"
 
 	"github.com/keithdoyle9/pipeline-mcp/internal/domain"
@@ -10,31 +9,26 @@ import (
 
 type Adapter interface {
 	ProviderID() string
-	ParseRepository(repository string) (owner string, repo string, err error)
+	ParseRepository(repository string) (string, error)
 	ParseRunURL(raw string) (*RunLocator, error)
 	ParseCheckRunURL(raw string) (int64, error)
-	RunURL(owner, repo string, runID int64) string
-	GetRun(ctx context.Context, owner, repo string, runID int64) (*Run, error)
-	ListRunJobs(ctx context.Context, owner, repo string, runID int64) ([]Job, error)
-	DownloadRunLogs(ctx context.Context, owner, repo string, runID int64, maxBytes int64) (string, error)
-	ListRepositoryRuns(ctx context.Context, owner, repo string, opts ListRunsOptions, maxRuns int) ([]Run, error)
-	GetCheckRun(ctx context.Context, owner, repo string, checkRunID int64) (*CheckRun, error)
-	GetCheckRunAnnotations(ctx context.Context, owner, repo string, checkRunID int64) ([]CheckRunAnnotation, error)
-	ListDeploymentBranchPolicies(ctx context.Context, owner, repo, environment string) ([]BranchPolicy, error)
-	Rerun(ctx context.Context, owner, repo string, runID int64, failedJobsOnly bool) error
+	RunURL(repository string, runID int64) string
+	GetRun(ctx context.Context, repository string, runID int64) (*Run, error)
+	ListRunJobs(ctx context.Context, repository string, runID int64) ([]Job, error)
+	DownloadRunLogs(ctx context.Context, repository string, runID int64, maxBytes int64) (string, error)
+	ListRepositoryRuns(ctx context.Context, repository string, opts ListRunsOptions, maxRuns int) ([]Run, error)
+	GetCheckRun(ctx context.Context, repository string, checkRunID int64) (*CheckRun, error)
+	GetCheckRunAnnotations(ctx context.Context, repository string, checkRunID int64) ([]CheckRunAnnotation, error)
+	ListDeploymentBranchPolicies(ctx context.Context, repository, environment string) ([]BranchPolicy, error)
+	Rerun(ctx context.Context, repository string, runID int64, failedJobsOnly bool) error
 	IsLogsUnavailable(err error) bool
 	MapError(err error) *domain.ToolError
 }
 
 type RunLocator struct {
-	Owner  string
-	Repo   string
-	RunID  int64
-	RunURL string
-}
-
-func (r RunLocator) Repository() string {
-	return fmt.Sprintf("%s/%s", r.Owner, r.Repo)
+	Repository string
+	RunID      int64
+	RunURL     string
 }
 
 type Run struct {

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -48,17 +48,17 @@ func (s *Service) GetRun(ctx context.Context, input RunReference) (*domain.Pipel
 		return nil, toolErr
 	}
 
-	run, err := s.provider.GetRun(ctx, resolved.Owner, resolved.Repo, resolved.RunID)
+	run, err := s.provider.GetRun(ctx, resolved.Repository, resolved.RunID)
 	if err != nil {
 		return nil, s.provider.MapError(err)
 	}
 
-	jobs, err := s.provider.ListRunJobs(ctx, resolved.Owner, resolved.Repo, resolved.RunID)
+	jobs, err := s.provider.ListRunJobs(ctx, resolved.Repository, resolved.RunID)
 	if err != nil {
-		s.logger.Warn("failed to fetch jobs for run", "repository", resolved.Repository(), "run_id", resolved.RunID, "error", err)
+		s.logger.Warn("failed to fetch jobs for run", "repository", resolved.Repository, "run_id", resolved.RunID, "error", err)
 	}
 
-	pipelineRun := normalizeRun(s.provider.ProviderID(), run, resolved.Repository(), jobs)
+	pipelineRun := normalizeRun(s.provider.ProviderID(), run, resolved.Repository, resolved.RunURL, jobs)
 	return &pipelineRun, nil
 }
 
@@ -75,19 +75,19 @@ func (s *Service) DiagnoseFailure(ctx context.Context, input RunReference, maxLo
 		maxLogBytes = s.cfg.MaxLogBytes
 	}
 
-	run, err := s.provider.GetRun(ctx, resolved.Owner, resolved.Repo, resolved.RunID)
+	run, err := s.provider.GetRun(ctx, resolved.Repository, resolved.RunID)
 	if err != nil {
 		return nil, nil, s.provider.MapError(err)
 	}
-	jobs, err := s.provider.ListRunJobs(ctx, resolved.Owner, resolved.Repo, resolved.RunID)
+	jobs, err := s.provider.ListRunJobs(ctx, resolved.Repository, resolved.RunID)
 	if err != nil {
 		return nil, nil, s.provider.MapError(err)
 	}
-	if diagnostic, recommendations, ok := s.diagnoseMetadataFailure(ctx, resolved.Owner, resolved.Repo, jobs); ok {
+	if diagnostic, recommendations, ok := s.diagnoseMetadataFailure(ctx, resolved.Repository, jobs); ok {
 		return diagnostic, recommendations, nil
 	}
 
-	logs, err := s.provider.DownloadRunLogs(ctx, resolved.Owner, resolved.Repo, resolved.RunID, maxLogBytes)
+	logs, err := s.provider.DownloadRunLogs(ctx, resolved.Repository, resolved.RunID, maxLogBytes)
 	if err != nil {
 		if s.provider.IsLogsUnavailable(err) {
 			return nil, nil, domain.NewToolError(
@@ -95,7 +95,7 @@ func (s *Service) DiagnoseFailure(ctx context.Context, input RunReference, maxLo
 				"Workflow logs are unavailable for this run.",
 				"Confirm the run still exists and your token has actions:read access, then retry.",
 				true,
-				map[string]any{"repository": resolved.Repository(), "run_id": resolved.RunID},
+				map[string]any{"repository": resolved.Repository, "run_id": resolved.RunID},
 			)
 		}
 		return nil, nil, s.provider.MapError(err)
@@ -112,7 +112,7 @@ func (s *Service) DiagnoseFailure(ctx context.Context, input RunReference, maxLo
 var envProtectionPattern = regexp.MustCompile(`Branch "([^"]+)" is not allowed to deploy to ([^ ]+) due to environment protection rules\.`)
 var approvalRequiredPattern = regexp.MustCompile(`(?i)(review required|required reviewers|approved review|approval.+required|not approved by required reviewers|awaiting review)`)
 
-func (s *Service) diagnoseMetadataFailure(ctx context.Context, owner, repo string, jobs []providers.Job) (*domain.FailureDiagnostic, []domain.FixRecommendation, bool) {
+func (s *Service) diagnoseMetadataFailure(ctx context.Context, repository string, jobs []providers.Job) (*domain.FailureDiagnostic, []domain.FixRecommendation, bool) {
 	for _, job := range jobs {
 		if !strings.EqualFold(job.Conclusion, "failure") {
 			continue
@@ -125,7 +125,7 @@ func (s *Service) diagnoseMetadataFailure(ctx context.Context, owner, repo strin
 		if err != nil {
 			continue
 		}
-		annotations, err := s.provider.GetCheckRunAnnotations(ctx, owner, repo, checkRunID)
+		annotations, err := s.provider.GetCheckRunAnnotations(ctx, repository, checkRunID)
 		if err != nil || len(annotations) == 0 {
 			continue
 		}
@@ -152,7 +152,7 @@ func (s *Service) diagnoseMetadataFailure(ctx context.Context, owner, repo strin
 			continue
 		}
 
-		checkRun, err := s.provider.GetCheckRun(ctx, owner, repo, checkRunID)
+		checkRun, err := s.provider.GetCheckRun(ctx, repository, checkRunID)
 		if err == nil && checkRun != nil && checkRun.Deployment != nil {
 			if environment == "" {
 				environment = firstNonEmpty(checkRun.Deployment.OriginalEnvironment, checkRun.Deployment.Environment)
@@ -182,7 +182,7 @@ func (s *Service) diagnoseMetadataFailure(ctx context.Context, owner, repo strin
 
 		var policies []providers.BranchPolicy
 		if environment != "the target environment" {
-			policies, err = s.provider.ListDeploymentBranchPolicies(ctx, owner, repo, environment)
+			policies, err = s.provider.ListDeploymentBranchPolicies(ctx, repository, environment)
 			if err != nil {
 				policies = nil
 			}
@@ -214,9 +214,9 @@ func (s *Service) diagnoseMetadataFailure(ctx context.Context, owner, repo strin
 }
 
 func (s *Service) AnalyzeFlakyTests(ctx context.Context, repository string, lookbackDays int, workflow string) (*domain.FlakyTestReport, *domain.ToolError) {
-	owner, repo, err := s.provider.ParseRepository(repository)
+	repository, err := s.provider.ParseRepository(repository)
 	if err != nil {
-		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide repository in owner/repo format.", false, nil)
+		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide a valid repository identifier for the active provider.", false, nil)
 	}
 	if lookbackDays <= 0 {
 		lookbackDays = s.cfg.DefaultLookbackDays
@@ -228,14 +228,14 @@ func (s *Service) AnalyzeFlakyTests(ctx context.Context, repository string, look
 	end := s.now().UTC()
 	start := end.AddDate(0, 0, -lookbackDays)
 	created := fmt.Sprintf("%s..%s", start.Format(time.RFC3339), end.Format(time.RFC3339))
-	runs, err := s.provider.ListRepositoryRuns(ctx, owner, repo, providers.ListRunsOptions{Created: created}, s.cfg.MaxHistoricalRuns)
+	runs, err := s.provider.ListRepositoryRuns(ctx, repository, providers.ListRunsOptions{Created: created}, s.cfg.MaxHistoricalRuns)
 	if err != nil {
 		return nil, s.provider.MapError(err)
 	}
 	runs = filterByWorkflow(runs, workflow)
 
 	report := analysis.AnalyzeFlakyTests(repository, workflow, lookbackDays, runs, func(runID int64) (string, error) {
-		return s.provider.DownloadRunLogs(ctx, owner, repo, runID, s.cfg.MaxLogBytes/2)
+		return s.provider.DownloadRunLogs(ctx, repository, runID, s.cfg.MaxLogBytes/2)
 	}, end)
 	return &report, nil
 }
@@ -244,9 +244,9 @@ func (s *Service) Rerun(ctx context.Context, repository string, runID int64, fai
 	if strings.TrimSpace(reason) == "" {
 		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, "reason is required", "Provide a short reason for auditability.", false, nil)
 	}
-	owner, repo, err := s.provider.ParseRepository(repository)
+	repository, err := s.provider.ParseRepository(repository)
 	if err != nil {
-		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide repository in owner/repo format.", false, nil)
+		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide a valid repository identifier for the active provider.", false, nil)
 	}
 	if runID <= 0 {
 		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, "run_id must be greater than zero", "Pass a valid GitHub Actions run id.", false, nil)
@@ -275,7 +275,7 @@ func (s *Service) Rerun(ctx context.Context, repository string, runID int64, fai
 		Actor:       s.cfg.Actor,
 	}
 
-	err = s.provider.Rerun(ctx, owner, repo, runID, failedJobsOnly)
+	err = s.provider.Rerun(ctx, repository, runID, failedJobsOnly)
 	outcome := "success"
 	if err != nil {
 		outcome = "failed"
@@ -292,9 +292,9 @@ func (s *Service) Rerun(ctx context.Context, repository string, runID int64, fai
 }
 
 func (s *Service) ComparePerformance(ctx context.Context, repository, workflow string, from, to time.Time) (*domain.PipelinePerformanceSnapshot, *domain.ToolError) {
-	owner, repo, err := s.provider.ParseRepository(repository)
+	repository, err := s.provider.ParseRepository(repository)
 	if err != nil {
-		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide repository in owner/repo format.", false, nil)
+		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide a valid repository identifier for the active provider.", false, nil)
 	}
 	if to.Before(from) || to.Equal(from) {
 		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, "to must be after from", "Provide a time range where to > from.", false, nil)
@@ -307,11 +307,11 @@ func (s *Service) ComparePerformance(ctx context.Context, repository, workflow s
 	currentRange := fmt.Sprintf("%s..%s", from.UTC().Format(time.RFC3339), to.UTC().Format(time.RFC3339))
 	baselineRange := fmt.Sprintf("%s..%s", baselineFrom.UTC().Format(time.RFC3339), baselineTo.UTC().Format(time.RFC3339))
 
-	currentRuns, err := s.provider.ListRepositoryRuns(ctx, owner, repo, providers.ListRunsOptions{Created: currentRange}, s.cfg.MaxHistoricalRuns)
+	currentRuns, err := s.provider.ListRepositoryRuns(ctx, repository, providers.ListRunsOptions{Created: currentRange}, s.cfg.MaxHistoricalRuns)
 	if err != nil {
 		return nil, s.provider.MapError(err)
 	}
-	baselineRuns, err := s.provider.ListRepositoryRuns(ctx, owner, repo, providers.ListRunsOptions{Created: baselineRange}, s.cfg.MaxHistoricalRuns)
+	baselineRuns, err := s.provider.ListRepositoryRuns(ctx, repository, providers.ListRunsOptions{Created: baselineRange}, s.cfg.MaxHistoricalRuns)
 	if err != nil {
 		return nil, s.provider.MapError(err)
 	}
@@ -341,7 +341,7 @@ func (s *Service) resolveRunReference(ctx context.Context, ref RunReference, all
 	if strings.TrimSpace(ref.RunURL) != "" {
 		locator, err := s.provider.ParseRunURL(ref.RunURL)
 		if err != nil {
-			return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide a valid GitHub Actions run URL.", false, nil)
+			return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide a valid pipeline run URL for the active provider.", false, nil)
 		}
 		return locator, nil
 	}
@@ -351,20 +351,20 @@ func (s *Service) resolveRunReference(ctx context.Context, ref RunReference, all
 		}
 		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, "either run_url or run_id must be provided", "Provide a run_url, or both run_id and repository, or repository alone to use the latest failed run.", false, nil)
 	}
-	owner, repo, err := s.provider.ParseRepository(ref.Repository)
+	repository, err := s.provider.ParseRepository(ref.Repository)
 	if err != nil {
-		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide repository in owner/repo format when using run_id.", false, nil)
+		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide a valid repository identifier when using run_id.", false, nil)
 	}
-	return &providers.RunLocator{Owner: owner, Repo: repo, RunID: ref.RunID, RunURL: s.provider.RunURL(owner, repo, ref.RunID)}, nil
+	return &providers.RunLocator{Repository: repository, RunID: ref.RunID, RunURL: s.provider.RunURL(repository, ref.RunID)}, nil
 }
 
 func (s *Service) resolveLatestFailedRun(ctx context.Context, repository string) (*providers.RunLocator, *domain.ToolError) {
-	owner, repo, err := s.provider.ParseRepository(repository)
+	repository, err := s.provider.ParseRepository(repository)
 	if err != nil {
-		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide repository in owner/repo format.", false, nil)
+		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide a valid repository identifier for the active provider.", false, nil)
 	}
 
-	runs, err := s.provider.ListRepositoryRuns(ctx, owner, repo, providers.ListRunsOptions{PerPage: 1, Status: "failure"}, 1)
+	runs, err := s.provider.ListRepositoryRuns(ctx, repository, providers.ListRunsOptions{PerPage: 1, Status: "failure"}, 1)
 	if err != nil {
 		return nil, s.provider.MapError(err)
 	}
@@ -381,18 +381,17 @@ func (s *Service) resolveLatestFailedRun(ctx context.Context, repository string)
 	run := runs[0]
 	runURL := strings.TrimSpace(run.RunURL)
 	if runURL == "" {
-		runURL = s.provider.RunURL(owner, repo, run.ID)
+		runURL = s.provider.RunURL(repository, run.ID)
 	}
 
 	return &providers.RunLocator{
-		Owner:  owner,
-		Repo:   repo,
-		RunID:  run.ID,
-		RunURL: runURL,
+		Repository: repository,
+		RunID:      run.ID,
+		RunURL:     runURL,
 	}, nil
 }
 
-func normalizeRun(providerID string, run *providers.Run, repository string, jobs []providers.Job) domain.PipelineRun {
+func normalizeRun(providerID string, run *providers.Run, repository, resolvedRunURL string, jobs []providers.Job) domain.PipelineRun {
 	workflow := run.Name
 	if strings.TrimSpace(workflow) == "" {
 		workflow = run.DisplayTitle
@@ -418,6 +417,10 @@ func normalizeRun(providerID string, run *providers.Run, repository string, jobs
 	if strings.TrimSpace(run.Conclusion) != "" {
 		status = run.Conclusion
 	}
+	runURL := strings.TrimSpace(run.RunURL)
+	if runURL == "" {
+		runURL = strings.TrimSpace(resolvedRunURL)
+	}
 
 	failureReason := ""
 	for _, job := range jobs {
@@ -436,7 +439,7 @@ func normalizeRun(providerID string, run *providers.Run, repository string, jobs
 		CompletedAt:   completedAt,
 		DurationMS:    durationMS,
 		QueueTimeMS:   queueTimeMS,
-		RunURL:        run.RunURL,
+		RunURL:        runURL,
 		CommitSHA:     run.HeadSHA,
 		RunID:         run.ID,
 		Conclusion:    run.Conclusion,

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -2,7 +2,6 @@ package service
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"log/slog"
 	"regexp"
@@ -13,34 +12,23 @@ import (
 	"github.com/keithdoyle9/pipeline-mcp/internal/analysis"
 	"github.com/keithdoyle9/pipeline-mcp/internal/audit"
 	"github.com/keithdoyle9/pipeline-mcp/internal/domain"
-	"github.com/keithdoyle9/pipeline-mcp/internal/githubapi"
+	"github.com/keithdoyle9/pipeline-mcp/internal/providers"
 	"github.com/keithdoyle9/pipeline-mcp/internal/telemetry"
 )
 
-type GitHubClient interface {
-	GetRun(ctx context.Context, owner, repo string, runID int64) (*githubapi.WorkflowRun, error)
-	ListRunJobs(ctx context.Context, owner, repo string, runID int64) ([]githubapi.Job, error)
-	DownloadRunLogs(ctx context.Context, owner, repo string, runID int64, maxBytes int64) (string, error)
-	ListRepositoryRuns(ctx context.Context, owner, repo string, opts githubapi.ListRunsOptions, maxRuns int) ([]githubapi.WorkflowRun, error)
-	GetCheckRun(ctx context.Context, owner, repo string, checkRunID int64) (*githubapi.CheckRun, error)
-	GetCheckRunAnnotations(ctx context.Context, owner, repo string, checkRunID int64) ([]githubapi.CheckRunAnnotation, error)
-	ListDeploymentBranchPolicies(ctx context.Context, owner, repo, environment string) ([]githubapi.BranchPolicy, error)
-	Rerun(ctx context.Context, owner, repo string, runID int64, failedJobsOnly bool) error
-}
-
 type Service struct {
 	cfg       *config.Config
-	github    GitHubClient
+	provider  providers.Adapter
 	audit     audit.Store
 	telemetry *telemetry.Collector
 	logger    *slog.Logger
 	now       func() time.Time
 }
 
-func New(cfg *config.Config, github GitHubClient, auditStore audit.Store, collector *telemetry.Collector, logger *slog.Logger) *Service {
+func New(cfg *config.Config, provider providers.Adapter, auditStore audit.Store, collector *telemetry.Collector, logger *slog.Logger) *Service {
 	return &Service{
 		cfg:       cfg,
-		github:    github,
+		provider:  provider,
 		audit:     auditStore,
 		telemetry: collector,
 		logger:    logger,
@@ -60,17 +48,17 @@ func (s *Service) GetRun(ctx context.Context, input RunReference) (*domain.Pipel
 		return nil, toolErr
 	}
 
-	run, err := s.github.GetRun(ctx, resolved.Owner, resolved.Repo, resolved.RunID)
+	run, err := s.provider.GetRun(ctx, resolved.Owner, resolved.Repo, resolved.RunID)
 	if err != nil {
-		return nil, mapProviderErr(err)
+		return nil, s.provider.MapError(err)
 	}
 
-	jobs, err := s.github.ListRunJobs(ctx, resolved.Owner, resolved.Repo, resolved.RunID)
+	jobs, err := s.provider.ListRunJobs(ctx, resolved.Owner, resolved.Repo, resolved.RunID)
 	if err != nil {
 		s.logger.Warn("failed to fetch jobs for run", "repository", resolved.Repository(), "run_id", resolved.RunID, "error", err)
 	}
 
-	pipelineRun := normalizeRun(run, resolved.Repository(), jobs)
+	pipelineRun := normalizeRun(s.provider.ProviderID(), run, resolved.Repository(), jobs)
 	return &pipelineRun, nil
 }
 
@@ -87,21 +75,21 @@ func (s *Service) DiagnoseFailure(ctx context.Context, input RunReference, maxLo
 		maxLogBytes = s.cfg.MaxLogBytes
 	}
 
-	run, err := s.github.GetRun(ctx, resolved.Owner, resolved.Repo, resolved.RunID)
+	run, err := s.provider.GetRun(ctx, resolved.Owner, resolved.Repo, resolved.RunID)
 	if err != nil {
-		return nil, nil, mapProviderErr(err)
+		return nil, nil, s.provider.MapError(err)
 	}
-	jobs, err := s.github.ListRunJobs(ctx, resolved.Owner, resolved.Repo, resolved.RunID)
+	jobs, err := s.provider.ListRunJobs(ctx, resolved.Owner, resolved.Repo, resolved.RunID)
 	if err != nil {
-		return nil, nil, mapProviderErr(err)
+		return nil, nil, s.provider.MapError(err)
 	}
 	if diagnostic, recommendations, ok := s.diagnoseMetadataFailure(ctx, resolved.Owner, resolved.Repo, jobs); ok {
 		return diagnostic, recommendations, nil
 	}
 
-	logs, err := s.github.DownloadRunLogs(ctx, resolved.Owner, resolved.Repo, resolved.RunID, maxLogBytes)
+	logs, err := s.provider.DownloadRunLogs(ctx, resolved.Owner, resolved.Repo, resolved.RunID, maxLogBytes)
 	if err != nil {
-		if errors.Is(err, githubapi.ErrLogsUnavailable) {
+		if s.provider.IsLogsUnavailable(err) {
 			return nil, nil, domain.NewToolError(
 				domain.ErrorCodeLogUnavailable,
 				"Workflow logs are unavailable for this run.",
@@ -110,7 +98,7 @@ func (s *Service) DiagnoseFailure(ctx context.Context, input RunReference, maxLo
 				map[string]any{"repository": resolved.Repository(), "run_id": resolved.RunID},
 			)
 		}
-		return nil, nil, mapProviderErr(err)
+		return nil, nil, s.provider.MapError(err)
 	}
 
 	redacted := analysis.RedactSecrets(logs)
@@ -124,7 +112,7 @@ func (s *Service) DiagnoseFailure(ctx context.Context, input RunReference, maxLo
 var envProtectionPattern = regexp.MustCompile(`Branch "([^"]+)" is not allowed to deploy to ([^ ]+) due to environment protection rules\.`)
 var approvalRequiredPattern = regexp.MustCompile(`(?i)(review required|required reviewers|approved review|approval.+required|not approved by required reviewers|awaiting review)`)
 
-func (s *Service) diagnoseMetadataFailure(ctx context.Context, owner, repo string, jobs []githubapi.Job) (*domain.FailureDiagnostic, []domain.FixRecommendation, bool) {
+func (s *Service) diagnoseMetadataFailure(ctx context.Context, owner, repo string, jobs []providers.Job) (*domain.FailureDiagnostic, []domain.FixRecommendation, bool) {
 	for _, job := range jobs {
 		if !strings.EqualFold(job.Conclusion, "failure") {
 			continue
@@ -133,11 +121,11 @@ func (s *Service) diagnoseMetadataFailure(ctx context.Context, owner, repo strin
 			continue
 		}
 
-		checkRunID, err := githubapi.ParseCheckRunURLForBase(job.CheckRunURL, s.cfg.GitHubAPIBaseURL)
+		checkRunID, err := s.provider.ParseCheckRunURL(job.CheckRunURL)
 		if err != nil {
 			continue
 		}
-		annotations, err := s.github.GetCheckRunAnnotations(ctx, owner, repo, checkRunID)
+		annotations, err := s.provider.GetCheckRunAnnotations(ctx, owner, repo, checkRunID)
 		if err != nil || len(annotations) == 0 {
 			continue
 		}
@@ -164,7 +152,7 @@ func (s *Service) diagnoseMetadataFailure(ctx context.Context, owner, repo strin
 			continue
 		}
 
-		checkRun, err := s.github.GetCheckRun(ctx, owner, repo, checkRunID)
+		checkRun, err := s.provider.GetCheckRun(ctx, owner, repo, checkRunID)
 		if err == nil && checkRun != nil && checkRun.Deployment != nil {
 			if environment == "" {
 				environment = firstNonEmpty(checkRun.Deployment.OriginalEnvironment, checkRun.Deployment.Environment)
@@ -192,9 +180,9 @@ func (s *Service) diagnoseMetadataFailure(ctx context.Context, owner, repo strin
 			continue
 		}
 
-		var policies []githubapi.BranchPolicy
+		var policies []providers.BranchPolicy
 		if environment != "the target environment" {
-			policies, err = s.github.ListDeploymentBranchPolicies(ctx, owner, repo, environment)
+			policies, err = s.provider.ListDeploymentBranchPolicies(ctx, owner, repo, environment)
 			if err != nil {
 				policies = nil
 			}
@@ -226,7 +214,7 @@ func (s *Service) diagnoseMetadataFailure(ctx context.Context, owner, repo strin
 }
 
 func (s *Service) AnalyzeFlakyTests(ctx context.Context, repository string, lookbackDays int, workflow string) (*domain.FlakyTestReport, *domain.ToolError) {
-	owner, repo, err := githubapi.ParseRepository(repository)
+	owner, repo, err := s.provider.ParseRepository(repository)
 	if err != nil {
 		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide repository in owner/repo format.", false, nil)
 	}
@@ -240,14 +228,14 @@ func (s *Service) AnalyzeFlakyTests(ctx context.Context, repository string, look
 	end := s.now().UTC()
 	start := end.AddDate(0, 0, -lookbackDays)
 	created := fmt.Sprintf("%s..%s", start.Format(time.RFC3339), end.Format(time.RFC3339))
-	runs, err := s.github.ListRepositoryRuns(ctx, owner, repo, githubapi.ListRunsOptions{Created: created}, s.cfg.MaxHistoricalRuns)
+	runs, err := s.provider.ListRepositoryRuns(ctx, owner, repo, providers.ListRunsOptions{Created: created}, s.cfg.MaxHistoricalRuns)
 	if err != nil {
-		return nil, mapProviderErr(err)
+		return nil, s.provider.MapError(err)
 	}
 	runs = filterByWorkflow(runs, workflow)
 
 	report := analysis.AnalyzeFlakyTests(repository, workflow, lookbackDays, runs, func(runID int64) (string, error) {
-		return s.github.DownloadRunLogs(ctx, owner, repo, runID, s.cfg.MaxLogBytes/2)
+		return s.provider.DownloadRunLogs(ctx, owner, repo, runID, s.cfg.MaxLogBytes/2)
 	}, end)
 	return &report, nil
 }
@@ -256,7 +244,7 @@ func (s *Service) Rerun(ctx context.Context, repository string, runID int64, fai
 	if strings.TrimSpace(reason) == "" {
 		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, "reason is required", "Provide a short reason for auditability.", false, nil)
 	}
-	owner, repo, err := githubapi.ParseRepository(repository)
+	owner, repo, err := s.provider.ParseRepository(repository)
 	if err != nil {
 		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide repository in owner/repo format.", false, nil)
 	}
@@ -287,11 +275,11 @@ func (s *Service) Rerun(ctx context.Context, repository string, runID int64, fai
 		Actor:       s.cfg.Actor,
 	}
 
-	err = s.github.Rerun(ctx, owner, repo, runID, failedJobsOnly)
+	err = s.provider.Rerun(ctx, owner, repo, runID, failedJobsOnly)
 	outcome := "success"
 	if err != nil {
 		outcome = "failed"
-		mapped := mapProviderErr(err)
+		mapped := s.provider.MapError(err)
 		_ = s.emitAudit(ctx, repository, runID, reason, scope, outcome)
 		return nil, mapped
 	}
@@ -304,7 +292,7 @@ func (s *Service) Rerun(ctx context.Context, repository string, runID int64, fai
 }
 
 func (s *Service) ComparePerformance(ctx context.Context, repository, workflow string, from, to time.Time) (*domain.PipelinePerformanceSnapshot, *domain.ToolError) {
-	owner, repo, err := githubapi.ParseRepository(repository)
+	owner, repo, err := s.provider.ParseRepository(repository)
 	if err != nil {
 		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide repository in owner/repo format.", false, nil)
 	}
@@ -319,13 +307,13 @@ func (s *Service) ComparePerformance(ctx context.Context, repository, workflow s
 	currentRange := fmt.Sprintf("%s..%s", from.UTC().Format(time.RFC3339), to.UTC().Format(time.RFC3339))
 	baselineRange := fmt.Sprintf("%s..%s", baselineFrom.UTC().Format(time.RFC3339), baselineTo.UTC().Format(time.RFC3339))
 
-	currentRuns, err := s.github.ListRepositoryRuns(ctx, owner, repo, githubapi.ListRunsOptions{Created: currentRange}, s.cfg.MaxHistoricalRuns)
+	currentRuns, err := s.provider.ListRepositoryRuns(ctx, owner, repo, providers.ListRunsOptions{Created: currentRange}, s.cfg.MaxHistoricalRuns)
 	if err != nil {
-		return nil, mapProviderErr(err)
+		return nil, s.provider.MapError(err)
 	}
-	baselineRuns, err := s.github.ListRepositoryRuns(ctx, owner, repo, githubapi.ListRunsOptions{Created: baselineRange}, s.cfg.MaxHistoricalRuns)
+	baselineRuns, err := s.provider.ListRepositoryRuns(ctx, owner, repo, providers.ListRunsOptions{Created: baselineRange}, s.cfg.MaxHistoricalRuns)
 	if err != nil {
-		return nil, mapProviderErr(err)
+		return nil, s.provider.MapError(err)
 	}
 	currentRuns = filterByWorkflow(currentRuns, workflow)
 	baselineRuns = filterByWorkflow(baselineRuns, workflow)
@@ -349,9 +337,9 @@ func (s *Service) emitAudit(ctx context.Context, repository string, runID int64,
 	return s.audit.Append(ctx, event)
 }
 
-func (s *Service) resolveRunReference(ctx context.Context, ref RunReference, allowRepositoryOnly bool) (*githubapi.RunLocator, *domain.ToolError) {
+func (s *Service) resolveRunReference(ctx context.Context, ref RunReference, allowRepositoryOnly bool) (*providers.RunLocator, *domain.ToolError) {
 	if strings.TrimSpace(ref.RunURL) != "" {
-		locator, err := githubapi.ParseRunURL(ref.RunURL)
+		locator, err := s.provider.ParseRunURL(ref.RunURL)
 		if err != nil {
 			return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide a valid GitHub Actions run URL.", false, nil)
 		}
@@ -363,22 +351,22 @@ func (s *Service) resolveRunReference(ctx context.Context, ref RunReference, all
 		}
 		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, "either run_url or run_id must be provided", "Provide a run_url, or both run_id and repository, or repository alone to use the latest failed run.", false, nil)
 	}
-	owner, repo, err := githubapi.ParseRepository(ref.Repository)
+	owner, repo, err := s.provider.ParseRepository(ref.Repository)
 	if err != nil {
 		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide repository in owner/repo format when using run_id.", false, nil)
 	}
-	return &githubapi.RunLocator{Owner: owner, Repo: repo, RunID: ref.RunID, RunURL: fmt.Sprintf("https://github.com/%s/%s/actions/runs/%d", owner, repo, ref.RunID)}, nil
+	return &providers.RunLocator{Owner: owner, Repo: repo, RunID: ref.RunID, RunURL: s.provider.RunURL(owner, repo, ref.RunID)}, nil
 }
 
-func (s *Service) resolveLatestFailedRun(ctx context.Context, repository string) (*githubapi.RunLocator, *domain.ToolError) {
-	owner, repo, err := githubapi.ParseRepository(repository)
+func (s *Service) resolveLatestFailedRun(ctx context.Context, repository string) (*providers.RunLocator, *domain.ToolError) {
+	owner, repo, err := s.provider.ParseRepository(repository)
 	if err != nil {
 		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide repository in owner/repo format.", false, nil)
 	}
 
-	runs, err := s.github.ListRepositoryRuns(ctx, owner, repo, githubapi.ListRunsOptions{PerPage: 1, Status: "failure"}, 1)
+	runs, err := s.provider.ListRepositoryRuns(ctx, owner, repo, providers.ListRunsOptions{PerPage: 1, Status: "failure"}, 1)
 	if err != nil {
-		return nil, mapProviderErr(err)
+		return nil, s.provider.MapError(err)
 	}
 	if len(runs) == 0 {
 		return nil, domain.NewToolError(
@@ -391,12 +379,12 @@ func (s *Service) resolveLatestFailedRun(ctx context.Context, repository string)
 	}
 
 	run := runs[0]
-	runURL := strings.TrimSpace(run.HTMLURL)
+	runURL := strings.TrimSpace(run.RunURL)
 	if runURL == "" {
-		runURL = fmt.Sprintf("https://github.com/%s/%s/actions/runs/%d", owner, repo, run.ID)
+		runURL = s.provider.RunURL(owner, repo, run.ID)
 	}
 
-	return &githubapi.RunLocator{
+	return &providers.RunLocator{
 		Owner:  owner,
 		Repo:   repo,
 		RunID:  run.ID,
@@ -404,35 +392,7 @@ func (s *Service) resolveLatestFailedRun(ctx context.Context, repository string)
 	}, nil
 }
 
-func mapProviderErr(err error) *domain.ToolError {
-	if err == nil {
-		return nil
-	}
-	if errors.Is(err, githubapi.ErrUnauthorized) || errors.Is(err, githubapi.ErrWriteTokenRequired) {
-		return domain.NewToolError(domain.ErrorCodeUnauthorized, "GitHub API authorization failed.", "Verify token scopes: actions:read for read tools and actions:write for rerun.", false, map[string]any{"error": err.Error()})
-	}
-	if errors.Is(err, githubapi.ErrNotFound) {
-		return domain.NewToolError(
-			domain.ErrorCodeUnauthorized,
-			"Run not found or access denied.",
-			"Confirm the run URL is correct and provide a token that can read this repository. For Claude Code, add the server with -e GITHUB_READ_TOKEN=... or -e GITHUB_TOKEN=....",
-			false,
-			map[string]any{"error": err.Error()},
-		)
-	}
-	if errors.Is(err, githubapi.ErrRateLimited) {
-		return domain.NewToolError(domain.ErrorCodeRateLimited, "GitHub API rate limit exceeded.", "Retry after backoff or increase API quota/token capacity.", true, map[string]any{"error": err.Error()})
-	}
-	if errors.Is(err, githubapi.ErrLogsUnavailable) {
-		return domain.NewToolError(domain.ErrorCodeLogUnavailable, "Run logs are unavailable.", "Check repository permissions and log retention settings.", true, map[string]any{"error": err.Error()})
-	}
-	if errors.Is(err, githubapi.ErrProviderUnavailable) {
-		return domain.NewToolError(domain.ErrorCodeProviderUnavailable, "GitHub API is unavailable.", "Retry with exponential backoff and check provider status.", true, map[string]any{"error": err.Error()})
-	}
-	return domain.NewToolError(domain.ErrorCodeInternal, "Unexpected internal error.", "Check server logs and retry.", true, map[string]any{"error": err.Error()})
-}
-
-func normalizeRun(run *githubapi.WorkflowRun, repository string, jobs []githubapi.Job) domain.PipelineRun {
+func normalizeRun(providerID string, run *providers.Run, repository string, jobs []providers.Job) domain.PipelineRun {
 	workflow := run.Name
 	if strings.TrimSpace(workflow) == "" {
 		workflow = run.DisplayTitle
@@ -468,7 +428,7 @@ func normalizeRun(run *githubapi.WorkflowRun, repository string, jobs []githubap
 	}
 
 	return domain.PipelineRun{
-		Provider:      domain.ProviderGitHub,
+		Provider:      providerID,
 		Repository:    repository,
 		Workflow:      workflow,
 		Status:        status,
@@ -476,7 +436,7 @@ func normalizeRun(run *githubapi.WorkflowRun, repository string, jobs []githubap
 		CompletedAt:   completedAt,
 		DurationMS:    durationMS,
 		QueueTimeMS:   queueTimeMS,
-		RunURL:        run.HTMLURL,
+		RunURL:        run.RunURL,
 		CommitSHA:     run.HeadSHA,
 		RunID:         run.ID,
 		Conclusion:    run.Conclusion,
@@ -484,12 +444,12 @@ func normalizeRun(run *githubapi.WorkflowRun, repository string, jobs []githubap
 	}
 }
 
-func filterByWorkflow(runs []githubapi.WorkflowRun, workflow string) []githubapi.WorkflowRun {
+func filterByWorkflow(runs []providers.Run, workflow string) []providers.Run {
 	workflow = strings.TrimSpace(workflow)
 	if workflow == "" {
 		return runs
 	}
-	filtered := make([]githubapi.WorkflowRun, 0, len(runs))
+	filtered := make([]providers.Run, 0, len(runs))
 	for _, run := range runs {
 		if strings.EqualFold(run.Name, workflow) || strings.EqualFold(run.DisplayTitle, workflow) {
 			filtered = append(filtered, run)

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -85,91 +86,118 @@ func (m *memoryAuditStore) Append(_ context.Context, event domain.AuditEvent) er
 	return nil
 }
 
-type seamTestProvider struct{}
+type seamTestProvider struct {
+	expectedRepository string
+	listRuns           []providers.Run
+	run                *providers.Run
+	jobs               []providers.Job
+	parsedRepository   string
+	fetchedRepository  string
+	listedRepository   string
+}
 
-func (seamTestProvider) ProviderID() string {
+func (p *seamTestProvider) ProviderID() string {
 	return "gitlab_ci"
 }
 
-func (seamTestProvider) ParseRepository(repository string) (string, string, error) {
-	if repository != "acme/app" {
-		return "", "", errors.New("unexpected repository")
+func (p *seamTestProvider) ParseRepository(repository string) (string, error) {
+	if repository != p.expectedRepository {
+		return "", errors.New("unexpected repository")
 	}
-	return "acme", "app", nil
+	p.parsedRepository = repository
+	return repository, nil
 }
 
-func (seamTestProvider) ParseRunURL(string) (*providers.RunLocator, error) {
+func (p *seamTestProvider) ParseRunURL(string) (*providers.RunLocator, error) {
 	return nil, errors.New("unexpected ParseRunURL call")
 }
 
-func (seamTestProvider) ParseCheckRunURL(string) (int64, error) {
+func (p *seamTestProvider) ParseCheckRunURL(string) (int64, error) {
 	return 0, errors.New("unexpected ParseCheckRunURL call")
 }
 
-func (seamTestProvider) RunURL(owner, repo string, runID int64) string {
-	return "https://ci.example/" + owner + "/" + repo + "/runs/55"
+func (p *seamTestProvider) RunURL(repository string, runID int64) string {
+	return "https://ci.example/" + repository + "/runs/" + strconv.FormatInt(runID, 10)
 }
 
-func (seamTestProvider) GetRun(context.Context, string, string, int64) (*providers.Run, error) {
+func (p *seamTestProvider) GetRun(_ context.Context, repository string, _ int64) (*providers.Run, error) {
+	p.fetchedRepository = repository
+	if p.run != nil {
+		return p.run, nil
+	}
 	return &providers.Run{
 		ID:         55,
 		Name:       "pipeline",
-		RunURL:     "https://ci.example/acme/app/runs/55",
 		HeadSHA:    "abc123",
 		Conclusion: "failure",
 	}, nil
 }
 
-func (seamTestProvider) ListRunJobs(context.Context, string, string, int64) ([]providers.Job, error) {
+func (p *seamTestProvider) ListRunJobs(_ context.Context, repository string, _ int64) ([]providers.Job, error) {
+	p.fetchedRepository = repository
+	if p.jobs != nil {
+		return p.jobs, nil
+	}
 	return []providers.Job{{Name: "unit", Conclusion: "failure"}}, nil
 }
 
-func (seamTestProvider) DownloadRunLogs(context.Context, string, string, int64, int64) (string, error) {
+func (p *seamTestProvider) DownloadRunLogs(context.Context, string, int64, int64) (string, error) {
 	return "", nil
 }
 
-func (seamTestProvider) ListRepositoryRuns(context.Context, string, string, providers.ListRunsOptions, int) ([]providers.Run, error) {
+func (p *seamTestProvider) ListRepositoryRuns(_ context.Context, repository string, _ providers.ListRunsOptions, _ int) ([]providers.Run, error) {
+	p.listedRepository = repository
+	return p.listRuns, nil
+}
+
+func (p *seamTestProvider) GetCheckRun(context.Context, string, int64) (*providers.CheckRun, error) {
 	return nil, nil
 }
 
-func (seamTestProvider) GetCheckRun(context.Context, string, string, int64) (*providers.CheckRun, error) {
+func (p *seamTestProvider) GetCheckRunAnnotations(context.Context, string, int64) ([]providers.CheckRunAnnotation, error) {
 	return nil, nil
 }
 
-func (seamTestProvider) GetCheckRunAnnotations(context.Context, string, string, int64) ([]providers.CheckRunAnnotation, error) {
+func (p *seamTestProvider) ListDeploymentBranchPolicies(context.Context, string, string) ([]providers.BranchPolicy, error) {
 	return nil, nil
 }
 
-func (seamTestProvider) ListDeploymentBranchPolicies(context.Context, string, string, string) ([]providers.BranchPolicy, error) {
-	return nil, nil
-}
-
-func (seamTestProvider) Rerun(context.Context, string, string, int64, bool) error {
+func (p *seamTestProvider) Rerun(context.Context, string, int64, bool) error {
 	return nil
 }
 
-func (seamTestProvider) IsLogsUnavailable(error) bool {
+func (p *seamTestProvider) IsLogsUnavailable(error) bool {
 	return false
 }
 
-func (seamTestProvider) MapError(err error) *domain.ToolError {
+func (p *seamTestProvider) MapError(err error) *domain.ToolError {
 	if err == nil {
 		return nil
 	}
 	return domain.NewToolError(domain.ErrorCodeInternal, err.Error(), "retry", true, nil)
 }
 
-func TestGetRunUsesProviderAdapterMetadata(t *testing.T) {
+func TestGetRunUsesProviderNativeRepositoryAndResolvedRunURL(t *testing.T) {
+	provider := &seamTestProvider{
+		expectedRepository: "group/subgroup/project",
+		run: &providers.Run{
+			ID:         55,
+			Name:       "pipeline",
+			HeadSHA:    "abc123",
+			Conclusion: "failure",
+		},
+		jobs: []providers.Job{{Name: "unit", Conclusion: "failure"}},
+	}
 	svc := &Service{
 		cfg:       testConfig(true),
-		provider:  seamTestProvider{},
+		provider:  provider,
 		audit:     &memoryAuditStore{},
 		telemetry: telemetry.NewCollector(""),
 		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
 		now:       time.Now,
 	}
 
-	run, toolErr := svc.GetRun(context.Background(), RunReference{Repository: "acme/app", RunID: 55})
+	run, toolErr := svc.GetRun(context.Background(), RunReference{Repository: "group/subgroup/project", RunID: 55})
 	if toolErr != nil {
 		t.Fatalf("unexpected tool error: %+v", toolErr)
 	}
@@ -179,11 +207,60 @@ func TestGetRunUsesProviderAdapterMetadata(t *testing.T) {
 	if run.Provider != "gitlab_ci" {
 		t.Fatalf("expected provider from adapter, got %q", run.Provider)
 	}
-	if run.RunURL != "https://ci.example/acme/app/runs/55" {
+	if provider.parsedRepository != "group/subgroup/project" {
+		t.Fatalf("expected ParseRepository to keep full path, got %q", provider.parsedRepository)
+	}
+	if provider.fetchedRepository != "group/subgroup/project" {
+		t.Fatalf("expected provider-native repository path, got %q", provider.fetchedRepository)
+	}
+	if run.Repository != "group/subgroup/project" {
+		t.Fatalf("expected repository to round-trip, got %q", run.Repository)
+	}
+	if run.RunURL != "https://ci.example/group/subgroup/project/runs/55" {
 		t.Fatalf("expected provider run url, got %q", run.RunURL)
 	}
 	if run.FailureReason != "job failed: unit" {
 		t.Fatalf("expected normalized failure reason, got %q", run.FailureReason)
+	}
+}
+
+func TestGetRunRepositoryOnlyFallsBackToResolvedRunURL(t *testing.T) {
+	provider := &seamTestProvider{
+		expectedRepository: "group/subgroup/project",
+		listRuns: []providers.Run{{
+			ID:         89,
+			Name:       "pipeline",
+			Conclusion: "failure",
+		}},
+		run: &providers.Run{
+			ID:         89,
+			Name:       "pipeline",
+			HeadSHA:    "abc123",
+			Conclusion: "failure",
+		},
+		jobs: []providers.Job{{Name: "unit", Conclusion: "failure"}},
+	}
+	svc := &Service{
+		cfg:       testConfig(true),
+		provider:  provider,
+		audit:     &memoryAuditStore{},
+		telemetry: telemetry.NewCollector(""),
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:       time.Now,
+	}
+
+	run, toolErr := svc.GetRun(context.Background(), RunReference{Repository: "group/subgroup/project"})
+	if toolErr != nil {
+		t.Fatalf("unexpected tool error: %+v", toolErr)
+	}
+	if provider.listedRepository != "group/subgroup/project" {
+		t.Fatalf("expected latest-run lookup to preserve full repository path, got %q", provider.listedRepository)
+	}
+	if run == nil {
+		t.Fatal("expected run")
+	}
+	if run.RunURL != "https://ci.example/group/subgroup/project/runs/89" {
+		t.Fatalf("expected resolved run url fallback, got %q", run.RunURL)
 	}
 }
 

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/keithdoyle9/pipeline-mcp/config"
 	"github.com/keithdoyle9/pipeline-mcp/internal/domain"
 	"github.com/keithdoyle9/pipeline-mcp/internal/githubapi"
+	"github.com/keithdoyle9/pipeline-mcp/internal/providers"
 	"github.com/keithdoyle9/pipeline-mcp/internal/telemetry"
 )
 
@@ -82,6 +83,108 @@ type memoryAuditStore struct {
 func (m *memoryAuditStore) Append(_ context.Context, event domain.AuditEvent) error {
 	m.events = append(m.events, event)
 	return nil
+}
+
+type seamTestProvider struct{}
+
+func (seamTestProvider) ProviderID() string {
+	return "gitlab_ci"
+}
+
+func (seamTestProvider) ParseRepository(repository string) (string, string, error) {
+	if repository != "acme/app" {
+		return "", "", errors.New("unexpected repository")
+	}
+	return "acme", "app", nil
+}
+
+func (seamTestProvider) ParseRunURL(string) (*providers.RunLocator, error) {
+	return nil, errors.New("unexpected ParseRunURL call")
+}
+
+func (seamTestProvider) ParseCheckRunURL(string) (int64, error) {
+	return 0, errors.New("unexpected ParseCheckRunURL call")
+}
+
+func (seamTestProvider) RunURL(owner, repo string, runID int64) string {
+	return "https://ci.example/" + owner + "/" + repo + "/runs/55"
+}
+
+func (seamTestProvider) GetRun(context.Context, string, string, int64) (*providers.Run, error) {
+	return &providers.Run{
+		ID:         55,
+		Name:       "pipeline",
+		RunURL:     "https://ci.example/acme/app/runs/55",
+		HeadSHA:    "abc123",
+		Conclusion: "failure",
+	}, nil
+}
+
+func (seamTestProvider) ListRunJobs(context.Context, string, string, int64) ([]providers.Job, error) {
+	return []providers.Job{{Name: "unit", Conclusion: "failure"}}, nil
+}
+
+func (seamTestProvider) DownloadRunLogs(context.Context, string, string, int64, int64) (string, error) {
+	return "", nil
+}
+
+func (seamTestProvider) ListRepositoryRuns(context.Context, string, string, providers.ListRunsOptions, int) ([]providers.Run, error) {
+	return nil, nil
+}
+
+func (seamTestProvider) GetCheckRun(context.Context, string, string, int64) (*providers.CheckRun, error) {
+	return nil, nil
+}
+
+func (seamTestProvider) GetCheckRunAnnotations(context.Context, string, string, int64) ([]providers.CheckRunAnnotation, error) {
+	return nil, nil
+}
+
+func (seamTestProvider) ListDeploymentBranchPolicies(context.Context, string, string, string) ([]providers.BranchPolicy, error) {
+	return nil, nil
+}
+
+func (seamTestProvider) Rerun(context.Context, string, string, int64, bool) error {
+	return nil
+}
+
+func (seamTestProvider) IsLogsUnavailable(error) bool {
+	return false
+}
+
+func (seamTestProvider) MapError(err error) *domain.ToolError {
+	if err == nil {
+		return nil
+	}
+	return domain.NewToolError(domain.ErrorCodeInternal, err.Error(), "retry", true, nil)
+}
+
+func TestGetRunUsesProviderAdapterMetadata(t *testing.T) {
+	svc := &Service{
+		cfg:       testConfig(true),
+		provider:  seamTestProvider{},
+		audit:     &memoryAuditStore{},
+		telemetry: telemetry.NewCollector(""),
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:       time.Now,
+	}
+
+	run, toolErr := svc.GetRun(context.Background(), RunReference{Repository: "acme/app", RunID: 55})
+	if toolErr != nil {
+		t.Fatalf("unexpected tool error: %+v", toolErr)
+	}
+	if run == nil {
+		t.Fatal("expected run")
+	}
+	if run.Provider != "gitlab_ci" {
+		t.Fatalf("expected provider from adapter, got %q", run.Provider)
+	}
+	if run.RunURL != "https://ci.example/acme/app/runs/55" {
+		t.Fatalf("expected provider run url, got %q", run.RunURL)
+	}
+	if run.FailureReason != "job failed: unit" {
+		t.Fatalf("expected normalized failure reason, got %q", run.FailureReason)
+	}
 }
 
 func TestDiagnoseFailureSuccess(t *testing.T) {
@@ -191,7 +294,7 @@ func TestRerunRequiresReasonAndAudit(t *testing.T) {
 
 	svc := &Service{
 		cfg:       cfg,
-		github:    mock,
+		provider:  githubapi.NewProviderAdapter(mock, cfg.GitHubAPIBaseURL),
 		audit:     auditStore,
 		telemetry: telemetry.NewCollector(""),
 		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -530,11 +633,11 @@ func TestDiagnoseFailureRepositoryOnlyReturnsHelpfulErrorWhenNoFailuresExist(t *
 	}
 }
 
-func newTestService(client GitHubClient, disableMutations bool) *Service {
+func newTestService(client *mockGitHubClient, disableMutations bool) *Service {
 	cfg := testConfig(disableMutations)
 	return &Service{
 		cfg:       cfg,
-		github:    client,
+		provider:  githubapi.NewProviderAdapter(client, cfg.GitHubAPIBaseURL),
 		audit:     &memoryAuditStore{},
 		telemetry: telemetry.NewCollector(""),
 		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),

--- a/tools/acceptance_test.go
+++ b/tools/acceptance_test.go
@@ -309,7 +309,7 @@ func newAcceptanceDependencies(t *testing.T, client *acceptanceGitHubClient, aud
 	}
 
 	return Dependencies{
-		Service:   service.New(cfg, client, auditStore, collector, logger),
+		Service:   service.New(cfg, githubapi.NewProviderAdapter(client, cfg.GitHubAPIBaseURL), auditStore, collector, logger),
 		Telemetry: collector,
 		Logger:    logger,
 	}

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -19,33 +19,33 @@ type Dependencies struct {
 }
 
 type RunLocatorInput struct {
-	RunURL     string `json:"run_url,omitempty" jsonschema:"GitHub Actions run URL"`
+	RunURL     string `json:"run_url,omitempty" jsonschema:"Pipeline run URL for the active provider"`
 	RunID      int64  `json:"run_id,omitempty" jsonschema:"GitHub Actions run id"`
-	Repository string `json:"repository,omitempty" jsonschema:"Repository in owner/repo format; required when using run_id, or accepted alone to resolve the latest failed run"`
+	Repository string `json:"repository,omitempty" jsonschema:"Repository identifier accepted by the active provider; required when using run_id, or accepted alone to resolve the latest failed run"`
 }
 
 type DiagnoseFailureInput struct {
-	RunURL      string `json:"run_url,omitempty" jsonschema:"GitHub Actions run URL"`
+	RunURL      string `json:"run_url,omitempty" jsonschema:"Pipeline run URL for the active provider"`
 	RunID       int64  `json:"run_id,omitempty" jsonschema:"GitHub Actions run id"`
-	Repository  string `json:"repository,omitempty" jsonschema:"Repository in owner/repo format; required when using run_id, or accepted alone to diagnose the latest failed run"`
+	Repository  string `json:"repository,omitempty" jsonschema:"Repository identifier accepted by the active provider; required when using run_id, or accepted alone to diagnose the latest failed run"`
 	MaxLogBytes int64  `json:"max_log_bytes,omitempty" jsonschema:"Max bytes of logs to ingest for analysis"`
 }
 
 type AnalyzeFlakyTestsInput struct {
-	Repository   string `json:"repository" jsonschema:"Repository in owner/repo format"`
+	Repository   string `json:"repository" jsonschema:"Repository identifier accepted by the active provider"`
 	LookbackDays int    `json:"lookback_days,omitempty" jsonschema:"How many days of run history to inspect"`
 	Workflow     string `json:"workflow,omitempty" jsonschema:"Optional workflow name filter"`
 }
 
 type RerunInput struct {
-	Repository     string `json:"repository" jsonschema:"Repository in owner/repo format"`
+	Repository     string `json:"repository" jsonschema:"Repository identifier accepted by the active provider"`
 	RunID          int64  `json:"run_id" jsonschema:"GitHub Actions run id"`
 	FailedJobsOnly bool   `json:"failed_jobs_only" jsonschema:"If true reruns only failed jobs"`
 	Reason         string `json:"reason" jsonschema:"Reason for rerun to persist in audit log"`
 }
 
 type ComparePerformanceInput struct {
-	Repository string `json:"repository" jsonschema:"Repository in owner/repo format"`
+	Repository string `json:"repository" jsonschema:"Repository identifier accepted by the active provider"`
 	Workflow   string `json:"workflow" jsonschema:"Workflow name to compare"`
 	From       string `json:"from" jsonschema:"Current window start (RFC3339 or YYYY-MM-DD)"`
 	To         string `json:"to" jsonschema:"Current window end (RFC3339 or YYYY-MM-DD)"`

--- a/tools/registry_test.go
+++ b/tools/registry_test.go
@@ -45,7 +45,13 @@ func (noopGitHubClient) Rerun(context.Context, string, string, int64, bool) erro
 
 func TestRegisterExposesFiveTools(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "pipeline-mcp-test", Version: "test"}, &mcp.ServerOptions{Capabilities: &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{}}})
-	svc := service.New(&config.Config{GitHubAPIBaseURL: "https://api.github.com", DisableMutations: true, MaxLogBytes: 1024, DefaultLookbackDays: 14, MaxHistoricalRuns: 100}, noopGitHubClient{}, audit.NewJSONLStore(t.TempDir()+"/audit.jsonl", ""), telemetry.NewCollector(""), slog.New(slog.NewTextHandler(io.Discard, nil)))
+	svc := service.New(
+		&config.Config{GitHubAPIBaseURL: "https://api.github.com", DisableMutations: true, MaxLogBytes: 1024, DefaultLookbackDays: 14, MaxHistoricalRuns: 100},
+		githubapi.NewProviderAdapter(noopGitHubClient{}, "https://api.github.com"),
+		audit.NewJSONLStore(t.TempDir()+"/audit.jsonl", ""),
+		telemetry.NewCollector(""),
+		slog.New(slog.NewTextHandler(io.Discard, nil)),
+	)
 	Register(server, Dependencies{Service: svc, Telemetry: telemetry.NewCollector(""), Logger: slog.New(slog.NewTextHandler(io.Discard, nil))})
 
 	client := mcp.NewClient(&mcp.Implementation{Name: "test-client", Version: "test"}, nil)


### PR DESCRIPTION
## Summary
- introduce provider-neutral adapter contracts and normalized pipeline run/job/check-run types
- route the existing GitHub implementation through a dedicated provider adapter without changing MCP tool contracts
- update analysis helpers, benchmark wiring, and regression coverage to operate through the new seam

Closes #10

## Testing
- `go fmt ./...`
- `GOCACHE=$(pwd)/.gocache go test ./...`

## Config impact
- none

## Contract impact
- none; tool names, inputs, and outputs are unchanged for current GitHub callers