### PR TITLE
Slice 14: add provider-aware routing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CodeQL](https://github.com/keithdoyle9/pipeline-mcp/actions/workflows/codeql.yml/badge.svg)](https://github.com/keithdoyle9/pipeline-mcp/actions/workflows/codeql.yml)
 [![License](https://img.shields.io/github/license/keithdoyle9/pipeline-mcp)](LICENSE)
 
-`pipeline-mcp` is a Go MCP server for CI/CD diagnosis and remediation workflows, starting with GitHub Actions.
+`pipeline-mcp` is a Go MCP server for CI/CD diagnosis and remediation workflows. GitHub Actions remains the default provider, and the tool inputs now accept an optional `provider` field for provider-aware routing.
 
 ## MVP Capabilities
 
@@ -13,6 +13,7 @@
 - `pipeline.analyze_flaky_tests`: identify top flaky tests by frequency, recency, and confidence.
 - `pipeline.rerun`: trigger controlled reruns with explicit reason and audit logging.
 - `pipeline.compare_performance`: compare current window metrics against an immediately preceding baseline window.
+- All tools accept an optional `provider` input; omitting it preserves GitHub Actions as the default.
 
 ## Open Source Defaults
 
@@ -136,6 +137,7 @@ Repository-only shortcut examples:
 ```text
 Use pipeline.get_run with repository="owner/repo" to inspect the latest failed run.
 Use pipeline.diagnose_failure with repository="owner/repo" to diagnose the latest failed run.
+Add provider="github_actions" explicitly only when you need to override default routing behavior.
 ```
 
 ## GitHub Repository Protections

--- a/cmd/benchmark/main.go
+++ b/cmd/benchmark/main.go
@@ -152,7 +152,7 @@ func evaluateFixture(fixture caseFixture) (benchmarkCaseResult, error) {
 	}
 	svc := service.New(
 		cfg,
-		githubapi.NewProviderAdapter(benchmarkGitHubClient{fixture: fixture}, cfg.GitHubAPIBaseURL),
+		mustProviderRegistry(githubapi.NewProviderAdapter(benchmarkGitHubClient{fixture: fixture}, cfg.GitHubAPIBaseURL)),
 		noopAuditStore{},
 		telemetry.NewCollector(""),
 		slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -175,6 +175,14 @@ func evaluateFixture(fixture caseFixture) (benchmarkCaseResult, error) {
 		MatchedTop3:      containsCategory(top3, fixture.ExpectedCategory),
 		LatencyMS:        latencyMS,
 	}, nil
+}
+
+func mustProviderRegistry(adapter providers.Adapter) *providers.Registry {
+	registry, err := providers.NewRegistry(adapter.ProviderID(), adapter)
+	if err != nil {
+		panic(err)
+	}
+	return registry
 }
 
 func summarizeResults(results []benchmarkCaseResult) benchmarkReport {

--- a/cmd/pipeline-mcp/main.go
+++ b/cmd/pipeline-mcp/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keithdoyle9/pipeline-mcp/config"
 	"github.com/keithdoyle9/pipeline-mcp/internal/audit"
 	"github.com/keithdoyle9/pipeline-mcp/internal/githubapi"
+	"github.com/keithdoyle9/pipeline-mcp/internal/providers"
 	"github.com/keithdoyle9/pipeline-mcp/internal/service"
 	"github.com/keithdoyle9/pipeline-mcp/internal/telemetry"
 	"github.com/keithdoyle9/pipeline-mcp/tools"
@@ -37,8 +38,12 @@ func run() error {
 	telemetryCollector := telemetry.NewCollector(cfg.MetricsExportPath)
 	ghClient := githubapi.NewClient(cfg.GitHubAPIBaseURL, cfg.GitHubReadToken, cfg.GitHubWriteToken, cfg.UserAgent, cfg.HTTPTimeout)
 	ghProvider := githubapi.NewProviderAdapter(ghClient, cfg.GitHubAPIBaseURL)
+	providerRegistry, err := providers.NewRegistry(ghProvider.ProviderID(), ghProvider)
+	if err != nil {
+		return fmt.Errorf("build provider registry: %w", err)
+	}
 	auditStore := audit.NewJSONLStore(cfg.AuditLogPath, cfg.AuditSigningKey)
-	svc := service.New(cfg, ghProvider, auditStore, telemetryCollector, logger)
+	svc := service.New(cfg, providerRegistry, auditStore, telemetryCollector, logger)
 
 	server := mcp.NewServer(&mcp.Implementation{
 		Name:    cfg.ServerName,

--- a/internal/providers/registry.go
+++ b/internal/providers/registry.go
@@ -1,0 +1,119 @@
+package providers
+
+import (
+	"fmt"
+	"strings"
+)
+
+type Registry struct {
+	defaultProvider string
+	adapters        map[string]Adapter
+	ordered         []Adapter
+}
+
+func NewRegistry(defaultProvider string, adapters ...Adapter) (*Registry, error) {
+	registry := &Registry{
+		defaultProvider: strings.TrimSpace(defaultProvider),
+		adapters:        make(map[string]Adapter, len(adapters)),
+		ordered:         make([]Adapter, 0, len(adapters)),
+	}
+
+	for _, adapter := range adapters {
+		if adapter == nil {
+			return nil, fmt.Errorf("provider adapter cannot be nil")
+		}
+		providerID := strings.TrimSpace(adapter.ProviderID())
+		if providerID == "" {
+			return nil, fmt.Errorf("provider adapter returned an empty provider id")
+		}
+		if _, exists := registry.adapters[providerID]; exists {
+			return nil, fmt.Errorf("provider %q is registered more than once", providerID)
+		}
+
+		registry.adapters[providerID] = adapter
+		registry.ordered = append(registry.ordered, adapter)
+	}
+
+	if len(registry.adapters) == 0 {
+		return nil, fmt.Errorf("at least one provider adapter is required")
+	}
+	if registry.defaultProvider == "" {
+		return nil, fmt.Errorf("default provider is required")
+	}
+	if _, ok := registry.adapters[registry.defaultProvider]; !ok {
+		return nil, fmt.Errorf("default provider %q is not registered", registry.defaultProvider)
+	}
+
+	return registry, nil
+}
+
+func (r *Registry) DefaultProviderID() string {
+	if r == nil {
+		return ""
+	}
+	return r.defaultProvider
+}
+
+func (r *Registry) ProviderIDs() []string {
+	if r == nil {
+		return nil
+	}
+	ids := make([]string, 0, len(r.ordered))
+	for _, adapter := range r.ordered {
+		ids = append(ids, adapter.ProviderID())
+	}
+	return ids
+}
+
+func (r *Registry) Resolve(providerID string) (Adapter, error) {
+	if r == nil {
+		return nil, fmt.Errorf("provider registry is not configured")
+	}
+
+	selected := strings.TrimSpace(providerID)
+	if selected == "" {
+		selected = r.defaultProvider
+	}
+
+	adapter, ok := r.adapters[selected]
+	if !ok {
+		return nil, fmt.Errorf("unsupported provider %q (supported: %s)", selected, strings.Join(r.ProviderIDs(), ", "))
+	}
+	return adapter, nil
+}
+
+func (r *Registry) ResolveRunURL(providerID, raw string) (Adapter, *RunLocator, error) {
+	if r == nil {
+		return nil, nil, fmt.Errorf("provider registry is not configured")
+	}
+
+	if explicit := strings.TrimSpace(providerID); explicit != "" {
+		adapter, err := r.Resolve(explicit)
+		if err != nil {
+			return nil, nil, err
+		}
+		locator, err := adapter.ParseRunURL(raw)
+		if err != nil {
+			return nil, nil, err
+		}
+		return adapter, locator, nil
+	}
+
+	if len(r.ordered) == 1 {
+		adapter := r.ordered[0]
+		locator, err := adapter.ParseRunURL(raw)
+		if err != nil {
+			return nil, nil, err
+		}
+		return adapter, locator, nil
+	}
+
+	for _, adapter := range r.ordered {
+		locator, err := adapter.ParseRunURL(raw)
+		if err == nil {
+			return adapter, locator, nil
+		}
+	}
+
+	return nil, nil, fmt.Errorf("run_url did not match any configured provider (supported: %s)", strings.Join(r.ProviderIDs(), ", "))
+}

--- a/internal/providers/registry_test.go
+++ b/internal/providers/registry_test.go
@@ -1,0 +1,140 @@
+package providers
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/keithdoyle9/pipeline-mcp/internal/domain"
+)
+
+type registryTestAdapter struct {
+	providerID string
+	runURL     string
+}
+
+func (a registryTestAdapter) ProviderID() string {
+	return a.providerID
+}
+
+func (a registryTestAdapter) ParseRepository(repository string) (string, error) {
+	return repository, nil
+}
+
+func (a registryTestAdapter) ParseRunURL(raw string) (*RunLocator, error) {
+	if raw != a.runURL {
+		return nil, errors.New("invalid run url")
+	}
+	return &RunLocator{Repository: a.providerID + "/repo", RunID: 42, RunURL: raw}, nil
+}
+
+func (a registryTestAdapter) ParseCheckRunURL(string) (int64, error) {
+	return 0, nil
+}
+
+func (a registryTestAdapter) RunURL(repository string, runID int64) string {
+	return a.runURL
+}
+
+func (a registryTestAdapter) GetRun(context.Context, string, int64) (*Run, error) {
+	return nil, nil
+}
+
+func (a registryTestAdapter) ListRunJobs(context.Context, string, int64) ([]Job, error) {
+	return nil, nil
+}
+
+func (a registryTestAdapter) DownloadRunLogs(context.Context, string, int64, int64) (string, error) {
+	return "", nil
+}
+
+func (a registryTestAdapter) ListRepositoryRuns(context.Context, string, ListRunsOptions, int) ([]Run, error) {
+	return nil, nil
+}
+
+func (a registryTestAdapter) GetCheckRun(context.Context, string, int64) (*CheckRun, error) {
+	return nil, nil
+}
+
+func (a registryTestAdapter) GetCheckRunAnnotations(context.Context, string, int64) ([]CheckRunAnnotation, error) {
+	return nil, nil
+}
+
+func (a registryTestAdapter) ListDeploymentBranchPolicies(context.Context, string, string) ([]BranchPolicy, error) {
+	return nil, nil
+}
+
+func (a registryTestAdapter) Rerun(context.Context, string, int64, bool) error {
+	return nil
+}
+
+func (a registryTestAdapter) IsLogsUnavailable(error) bool {
+	return false
+}
+
+func (a registryTestAdapter) MapError(err error) *domain.ToolError {
+	if err == nil {
+		return nil
+	}
+	return domain.NewToolError(domain.ErrorCodeInternal, err.Error(), "retry", true, nil)
+}
+
+func TestRegistryResolveDefaultsToConfiguredProvider(t *testing.T) {
+	registry, err := NewRegistry(
+		"github_actions",
+		registryTestAdapter{providerID: "github_actions", runURL: "https://github.example/runs/1"},
+		registryTestAdapter{providerID: "gitlab_ci", runURL: "https://gitlab.example/pipelines/1"},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	adapter, err := registry.Resolve("")
+	if err != nil {
+		t.Fatalf("Resolve() error = %v", err)
+	}
+	if adapter.ProviderID() != "github_actions" {
+		t.Fatalf("expected default provider github_actions, got %q", adapter.ProviderID())
+	}
+}
+
+func TestRegistryResolveRunURLInfersProvider(t *testing.T) {
+	registry, err := NewRegistry(
+		"github_actions",
+		registryTestAdapter{providerID: "github_actions", runURL: "https://github.example/runs/1"},
+		registryTestAdapter{providerID: "gitlab_ci", runURL: "https://gitlab.example/pipelines/1"},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	adapter, locator, err := registry.ResolveRunURL("", "https://gitlab.example/pipelines/1")
+	if err != nil {
+		t.Fatalf("ResolveRunURL() error = %v", err)
+	}
+	if adapter.ProviderID() != "gitlab_ci" {
+		t.Fatalf("expected gitlab_ci provider, got %q", adapter.ProviderID())
+	}
+	if locator == nil || locator.RunID != 42 {
+		t.Fatalf("expected resolved locator, got %+v", locator)
+	}
+}
+
+func TestRegistryResolveRejectsUnknownProvider(t *testing.T) {
+	registry, err := NewRegistry(
+		"github_actions",
+		registryTestAdapter{providerID: "github_actions", runURL: "https://github.example/runs/1"},
+	)
+	if err != nil {
+		t.Fatalf("NewRegistry() error = %v", err)
+	}
+
+	_, err = registry.Resolve("circleci")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if !strings.Contains(err.Error(), "unsupported provider") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -18,17 +18,17 @@ import (
 
 type Service struct {
 	cfg       *config.Config
-	provider  providers.Adapter
+	providers *providers.Registry
 	audit     audit.Store
 	telemetry *telemetry.Collector
 	logger    *slog.Logger
 	now       func() time.Time
 }
 
-func New(cfg *config.Config, provider providers.Adapter, auditStore audit.Store, collector *telemetry.Collector, logger *slog.Logger) *Service {
+func New(cfg *config.Config, registry *providers.Registry, auditStore audit.Store, collector *telemetry.Collector, logger *slog.Logger) *Service {
 	return &Service{
 		cfg:       cfg,
-		provider:  provider,
+		providers: registry,
 		audit:     auditStore,
 		telemetry: collector,
 		logger:    logger,
@@ -37,33 +37,34 @@ func New(cfg *config.Config, provider providers.Adapter, auditStore audit.Store,
 }
 
 type RunReference struct {
+	Provider   string
 	RunURL     string
 	RunID      int64
 	Repository string
 }
 
 func (s *Service) GetRun(ctx context.Context, input RunReference) (*domain.PipelineRun, *domain.ToolError) {
-	resolved, toolErr := s.resolveRunReference(ctx, input, true)
+	provider, resolved, toolErr := s.resolveRunReference(ctx, input, true)
 	if toolErr != nil {
 		return nil, toolErr
 	}
 
-	run, err := s.provider.GetRun(ctx, resolved.Repository, resolved.RunID)
+	run, err := provider.GetRun(ctx, resolved.Repository, resolved.RunID)
 	if err != nil {
-		return nil, s.provider.MapError(err)
+		return nil, provider.MapError(err)
 	}
 
-	jobs, err := s.provider.ListRunJobs(ctx, resolved.Repository, resolved.RunID)
+	jobs, err := provider.ListRunJobs(ctx, resolved.Repository, resolved.RunID)
 	if err != nil {
 		s.logger.Warn("failed to fetch jobs for run", "repository", resolved.Repository, "run_id", resolved.RunID, "error", err)
 	}
 
-	pipelineRun := normalizeRun(s.provider.ProviderID(), run, resolved.Repository, resolved.RunURL, jobs)
+	pipelineRun := normalizeRun(provider.ProviderID(), run, resolved.Repository, resolved.RunURL, jobs)
 	return &pipelineRun, nil
 }
 
 func (s *Service) DiagnoseFailure(ctx context.Context, input RunReference, maxLogBytes int64) (*domain.FailureDiagnostic, []domain.FixRecommendation, *domain.ToolError) {
-	resolved, toolErr := s.resolveRunReference(ctx, input, true)
+	provider, resolved, toolErr := s.resolveRunReference(ctx, input, true)
 	if toolErr != nil {
 		return nil, nil, toolErr
 	}
@@ -75,21 +76,21 @@ func (s *Service) DiagnoseFailure(ctx context.Context, input RunReference, maxLo
 		maxLogBytes = s.cfg.MaxLogBytes
 	}
 
-	run, err := s.provider.GetRun(ctx, resolved.Repository, resolved.RunID)
+	run, err := provider.GetRun(ctx, resolved.Repository, resolved.RunID)
 	if err != nil {
-		return nil, nil, s.provider.MapError(err)
+		return nil, nil, provider.MapError(err)
 	}
-	jobs, err := s.provider.ListRunJobs(ctx, resolved.Repository, resolved.RunID)
+	jobs, err := provider.ListRunJobs(ctx, resolved.Repository, resolved.RunID)
 	if err != nil {
-		return nil, nil, s.provider.MapError(err)
+		return nil, nil, provider.MapError(err)
 	}
-	if diagnostic, recommendations, ok := s.diagnoseMetadataFailure(ctx, resolved.Repository, jobs); ok {
+	if diagnostic, recommendations, ok := s.diagnoseMetadataFailure(ctx, provider, resolved.Repository, jobs); ok {
 		return diagnostic, recommendations, nil
 	}
 
-	logs, err := s.provider.DownloadRunLogs(ctx, resolved.Repository, resolved.RunID, maxLogBytes)
+	logs, err := provider.DownloadRunLogs(ctx, resolved.Repository, resolved.RunID, maxLogBytes)
 	if err != nil {
-		if s.provider.IsLogsUnavailable(err) {
+		if provider.IsLogsUnavailable(err) {
 			return nil, nil, domain.NewToolError(
 				domain.ErrorCodeLogUnavailable,
 				"Workflow logs are unavailable for this run.",
@@ -98,7 +99,7 @@ func (s *Service) DiagnoseFailure(ctx context.Context, input RunReference, maxLo
 				map[string]any{"repository": resolved.Repository, "run_id": resolved.RunID},
 			)
 		}
-		return nil, nil, s.provider.MapError(err)
+		return nil, nil, provider.MapError(err)
 	}
 
 	redacted := analysis.RedactSecrets(logs)
@@ -112,7 +113,7 @@ func (s *Service) DiagnoseFailure(ctx context.Context, input RunReference, maxLo
 var envProtectionPattern = regexp.MustCompile(`Branch "([^"]+)" is not allowed to deploy to ([^ ]+) due to environment protection rules\.`)
 var approvalRequiredPattern = regexp.MustCompile(`(?i)(review required|required reviewers|approved review|approval.+required|not approved by required reviewers|awaiting review)`)
 
-func (s *Service) diagnoseMetadataFailure(ctx context.Context, repository string, jobs []providers.Job) (*domain.FailureDiagnostic, []domain.FixRecommendation, bool) {
+func (s *Service) diagnoseMetadataFailure(ctx context.Context, provider providers.Adapter, repository string, jobs []providers.Job) (*domain.FailureDiagnostic, []domain.FixRecommendation, bool) {
 	for _, job := range jobs {
 		if !strings.EqualFold(job.Conclusion, "failure") {
 			continue
@@ -121,11 +122,11 @@ func (s *Service) diagnoseMetadataFailure(ctx context.Context, repository string
 			continue
 		}
 
-		checkRunID, err := s.provider.ParseCheckRunURL(job.CheckRunURL)
+		checkRunID, err := provider.ParseCheckRunURL(job.CheckRunURL)
 		if err != nil {
 			continue
 		}
-		annotations, err := s.provider.GetCheckRunAnnotations(ctx, repository, checkRunID)
+		annotations, err := provider.GetCheckRunAnnotations(ctx, repository, checkRunID)
 		if err != nil || len(annotations) == 0 {
 			continue
 		}
@@ -152,7 +153,7 @@ func (s *Service) diagnoseMetadataFailure(ctx context.Context, repository string
 			continue
 		}
 
-		checkRun, err := s.provider.GetCheckRun(ctx, repository, checkRunID)
+		checkRun, err := provider.GetCheckRun(ctx, repository, checkRunID)
 		if err == nil && checkRun != nil && checkRun.Deployment != nil {
 			if environment == "" {
 				environment = firstNonEmpty(checkRun.Deployment.OriginalEnvironment, checkRun.Deployment.Environment)
@@ -182,7 +183,7 @@ func (s *Service) diagnoseMetadataFailure(ctx context.Context, repository string
 
 		var policies []providers.BranchPolicy
 		if environment != "the target environment" {
-			policies, err = s.provider.ListDeploymentBranchPolicies(ctx, repository, environment)
+			policies, err = provider.ListDeploymentBranchPolicies(ctx, repository, environment)
 			if err != nil {
 				policies = nil
 			}
@@ -213,10 +214,15 @@ func (s *Service) diagnoseMetadataFailure(ctx context.Context, repository string
 	return nil, nil, false
 }
 
-func (s *Service) AnalyzeFlakyTests(ctx context.Context, repository string, lookbackDays int, workflow string) (*domain.FlakyTestReport, *domain.ToolError) {
-	repository, err := s.provider.ParseRepository(repository)
+func (s *Service) AnalyzeFlakyTests(ctx context.Context, providerID, repository string, lookbackDays int, workflow string) (*domain.FlakyTestReport, *domain.ToolError) {
+	provider, toolErr := s.resolveProvider(providerID)
+	if toolErr != nil {
+		return nil, toolErr
+	}
+
+	repository, err := provider.ParseRepository(repository)
 	if err != nil {
-		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide a valid repository identifier for the active provider.", false, nil)
+		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), s.repositoryRemediation(provider.ProviderID()), false, providerDetails(provider.ProviderID(), s.providers.ProviderIDs()))
 	}
 	if lookbackDays <= 0 {
 		lookbackDays = s.cfg.DefaultLookbackDays
@@ -228,28 +234,33 @@ func (s *Service) AnalyzeFlakyTests(ctx context.Context, repository string, look
 	end := s.now().UTC()
 	start := end.AddDate(0, 0, -lookbackDays)
 	created := fmt.Sprintf("%s..%s", start.Format(time.RFC3339), end.Format(time.RFC3339))
-	runs, err := s.provider.ListRepositoryRuns(ctx, repository, providers.ListRunsOptions{Created: created}, s.cfg.MaxHistoricalRuns)
+	runs, err := provider.ListRepositoryRuns(ctx, repository, providers.ListRunsOptions{Created: created}, s.cfg.MaxHistoricalRuns)
 	if err != nil {
-		return nil, s.provider.MapError(err)
+		return nil, provider.MapError(err)
 	}
 	runs = filterByWorkflow(runs, workflow)
 
 	report := analysis.AnalyzeFlakyTests(repository, workflow, lookbackDays, runs, func(runID int64) (string, error) {
-		return s.provider.DownloadRunLogs(ctx, repository, runID, s.cfg.MaxLogBytes/2)
+		return provider.DownloadRunLogs(ctx, repository, runID, s.cfg.MaxLogBytes/2)
 	}, end)
 	return &report, nil
 }
 
-func (s *Service) Rerun(ctx context.Context, repository string, runID int64, failedJobsOnly bool, reason string) (*domain.RerunResult, *domain.ToolError) {
+func (s *Service) Rerun(ctx context.Context, providerID, repository string, runID int64, failedJobsOnly bool, reason string) (*domain.RerunResult, *domain.ToolError) {
+	provider, toolErr := s.resolveProvider(providerID)
+	if toolErr != nil {
+		return nil, toolErr
+	}
+
 	if strings.TrimSpace(reason) == "" {
 		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, "reason is required", "Provide a short reason for auditability.", false, nil)
 	}
-	repository, err := s.provider.ParseRepository(repository)
+	repository, err := provider.ParseRepository(repository)
 	if err != nil {
-		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide a valid repository identifier for the active provider.", false, nil)
+		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), s.repositoryRemediation(provider.ProviderID()), false, providerDetails(provider.ProviderID(), s.providers.ProviderIDs()))
 	}
 	if runID <= 0 {
-		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, "run_id must be greater than zero", "Pass a valid GitHub Actions run id.", false, nil)
+		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, "run_id must be greater than zero", fmt.Sprintf("Pass a valid run id for provider %q.", provider.ProviderID()), false, nil)
 	}
 	if s.cfg.DisableMutations {
 		return nil, domain.NewToolError(
@@ -275,11 +286,11 @@ func (s *Service) Rerun(ctx context.Context, repository string, runID int64, fai
 		Actor:       s.cfg.Actor,
 	}
 
-	err = s.provider.Rerun(ctx, repository, runID, failedJobsOnly)
+	err = provider.Rerun(ctx, repository, runID, failedJobsOnly)
 	outcome := "success"
 	if err != nil {
 		outcome = "failed"
-		mapped := s.provider.MapError(err)
+		mapped := provider.MapError(err)
 		_ = s.emitAudit(ctx, repository, runID, reason, scope, outcome)
 		return nil, mapped
 	}
@@ -291,10 +302,15 @@ func (s *Service) Rerun(ctx context.Context, repository string, runID int64, fai
 	return result, nil
 }
 
-func (s *Service) ComparePerformance(ctx context.Context, repository, workflow string, from, to time.Time) (*domain.PipelinePerformanceSnapshot, *domain.ToolError) {
-	repository, err := s.provider.ParseRepository(repository)
+func (s *Service) ComparePerformance(ctx context.Context, providerID, repository, workflow string, from, to time.Time) (*domain.PipelinePerformanceSnapshot, *domain.ToolError) {
+	provider, toolErr := s.resolveProvider(providerID)
+	if toolErr != nil {
+		return nil, toolErr
+	}
+
+	repository, err := provider.ParseRepository(repository)
 	if err != nil {
-		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide a valid repository identifier for the active provider.", false, nil)
+		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), s.repositoryRemediation(provider.ProviderID()), false, providerDetails(provider.ProviderID(), s.providers.ProviderIDs()))
 	}
 	if to.Before(from) || to.Equal(from) {
 		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, "to must be after from", "Provide a time range where to > from.", false, nil)
@@ -307,13 +323,13 @@ func (s *Service) ComparePerformance(ctx context.Context, repository, workflow s
 	currentRange := fmt.Sprintf("%s..%s", from.UTC().Format(time.RFC3339), to.UTC().Format(time.RFC3339))
 	baselineRange := fmt.Sprintf("%s..%s", baselineFrom.UTC().Format(time.RFC3339), baselineTo.UTC().Format(time.RFC3339))
 
-	currentRuns, err := s.provider.ListRepositoryRuns(ctx, repository, providers.ListRunsOptions{Created: currentRange}, s.cfg.MaxHistoricalRuns)
+	currentRuns, err := provider.ListRepositoryRuns(ctx, repository, providers.ListRunsOptions{Created: currentRange}, s.cfg.MaxHistoricalRuns)
 	if err != nil {
-		return nil, s.provider.MapError(err)
+		return nil, provider.MapError(err)
 	}
-	baselineRuns, err := s.provider.ListRepositoryRuns(ctx, repository, providers.ListRunsOptions{Created: baselineRange}, s.cfg.MaxHistoricalRuns)
+	baselineRuns, err := provider.ListRepositoryRuns(ctx, repository, providers.ListRunsOptions{Created: baselineRange}, s.cfg.MaxHistoricalRuns)
 	if err != nil {
-		return nil, s.provider.MapError(err)
+		return nil, provider.MapError(err)
 	}
 	currentRuns = filterByWorkflow(currentRuns, workflow)
 	baselineRuns = filterByWorkflow(baselineRuns, workflow)
@@ -337,51 +353,63 @@ func (s *Service) emitAudit(ctx context.Context, repository string, runID int64,
 	return s.audit.Append(ctx, event)
 }
 
-func (s *Service) resolveRunReference(ctx context.Context, ref RunReference, allowRepositoryOnly bool) (*providers.RunLocator, *domain.ToolError) {
+func (s *Service) resolveRunReference(ctx context.Context, ref RunReference, allowRepositoryOnly bool) (providers.Adapter, *providers.RunLocator, *domain.ToolError) {
 	if strings.TrimSpace(ref.RunURL) != "" {
-		locator, err := s.provider.ParseRunURL(ref.RunURL)
-		if err != nil {
-			return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide a valid pipeline run URL for the active provider.", false, nil)
+		provider, locator, toolErr := s.resolveProviderForRunURL(ref.Provider, ref.RunURL)
+		if toolErr != nil {
+			return nil, nil, toolErr
 		}
-		return locator, nil
+		return provider, locator, nil
 	}
 	if ref.RunID <= 0 {
 		if allowRepositoryOnly && strings.TrimSpace(ref.Repository) != "" {
-			return s.resolveLatestFailedRun(ctx, ref.Repository)
+			provider, toolErr := s.resolveProvider(ref.Provider)
+			if toolErr != nil {
+				return nil, nil, toolErr
+			}
+			locator, toolErr := s.resolveLatestFailedRun(ctx, provider, ref.Repository)
+			if toolErr != nil {
+				return nil, nil, toolErr
+			}
+			return provider, locator, nil
 		}
-		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, "either run_url or run_id must be provided", "Provide a run_url, or both run_id and repository, or repository alone to use the latest failed run.", false, nil)
+		return nil, nil, domain.NewToolError(domain.ErrorCodeInvalidInput, "either run_url or run_id must be provided", "Provide a run_url, or both run_id and repository, or repository alone to use the latest failed run.", false, nil)
 	}
-	repository, err := s.provider.ParseRepository(ref.Repository)
+	provider, toolErr := s.resolveProvider(ref.Provider)
+	if toolErr != nil {
+		return nil, nil, toolErr
+	}
+	repository, err := provider.ParseRepository(ref.Repository)
 	if err != nil {
-		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide a valid repository identifier when using run_id.", false, nil)
+		return nil, nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), fmt.Sprintf("Provide a valid repository identifier when using run_id with provider %q.", provider.ProviderID()), false, providerDetails(provider.ProviderID(), s.providers.ProviderIDs()))
 	}
-	return &providers.RunLocator{Repository: repository, RunID: ref.RunID, RunURL: s.provider.RunURL(repository, ref.RunID)}, nil
+	return provider, &providers.RunLocator{Repository: repository, RunID: ref.RunID, RunURL: provider.RunURL(repository, ref.RunID)}, nil
 }
 
-func (s *Service) resolveLatestFailedRun(ctx context.Context, repository string) (*providers.RunLocator, *domain.ToolError) {
-	repository, err := s.provider.ParseRepository(repository)
+func (s *Service) resolveLatestFailedRun(ctx context.Context, provider providers.Adapter, repository string) (*providers.RunLocator, *domain.ToolError) {
+	repository, err := provider.ParseRepository(repository)
 	if err != nil {
-		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), "Provide a valid repository identifier for the active provider.", false, nil)
+		return nil, domain.NewToolError(domain.ErrorCodeInvalidInput, err.Error(), s.repositoryRemediation(provider.ProviderID()), false, providerDetails(provider.ProviderID(), s.providers.ProviderIDs()))
 	}
 
-	runs, err := s.provider.ListRepositoryRuns(ctx, repository, providers.ListRunsOptions{PerPage: 1, Status: "failure"}, 1)
+	runs, err := provider.ListRepositoryRuns(ctx, repository, providers.ListRunsOptions{PerPage: 1, Status: "failure"}, 1)
 	if err != nil {
-		return nil, s.provider.MapError(err)
+		return nil, provider.MapError(err)
 	}
 	if len(runs) == 0 {
 		return nil, domain.NewToolError(
 			domain.ErrorCodeInvalidInput,
 			"No failed workflow runs were found for this repository.",
-			"Provide a specific run_url, or retry after a failed GitHub Actions run exists in the repository.",
+			fmt.Sprintf("Provide a specific run_url, or retry after a failed run exists for provider %q.", provider.ProviderID()),
 			false,
-			map[string]any{"repository": repository},
+			providerDetails(provider.ProviderID(), s.providers.ProviderIDs(), map[string]any{"repository": repository}),
 		)
 	}
 
 	run := runs[0]
 	runURL := strings.TrimSpace(run.RunURL)
 	if runURL == "" {
-		runURL = s.provider.RunURL(repository, run.ID)
+		runURL = provider.RunURL(repository, run.ID)
 	}
 
 	return &providers.RunLocator{
@@ -389,6 +417,58 @@ func (s *Service) resolveLatestFailedRun(ctx context.Context, repository string)
 		RunID:      run.ID,
 		RunURL:     runURL,
 	}, nil
+}
+
+func (s *Service) resolveProvider(providerID string) (providers.Adapter, *domain.ToolError) {
+	adapter, err := s.providers.Resolve(providerID)
+	if err != nil {
+		return nil, domain.NewToolError(
+			domain.ErrorCodeInvalidInput,
+			err.Error(),
+			fmt.Sprintf("Omit provider to use the default %q, or choose one of: %s.", s.providers.DefaultProviderID(), strings.Join(s.providers.ProviderIDs(), ", ")),
+			false,
+			providerDetails(strings.TrimSpace(providerID), s.providers.ProviderIDs()),
+		)
+	}
+	return adapter, nil
+}
+
+func (s *Service) resolveProviderForRunURL(providerID, runURL string) (providers.Adapter, *providers.RunLocator, *domain.ToolError) {
+	adapter, locator, err := s.providers.ResolveRunURL(providerID, runURL)
+	if err != nil {
+		return nil, nil, domain.NewToolError(
+			domain.ErrorCodeInvalidInput,
+			err.Error(),
+			s.runURLRemediation(strings.TrimSpace(providerID)),
+			false,
+			providerDetails(strings.TrimSpace(providerID), s.providers.ProviderIDs(), map[string]any{"run_url": runURL}),
+		)
+	}
+	return adapter, locator, nil
+}
+
+func (s *Service) repositoryRemediation(providerID string) string {
+	return fmt.Sprintf("Provide a valid repository identifier for provider %q.", providerID)
+}
+
+func (s *Service) runURLRemediation(providerID string) string {
+	if providerID != "" {
+		return fmt.Sprintf("Provide a valid pipeline run URL for provider %q.", providerID)
+	}
+	return fmt.Sprintf("Provide a valid pipeline run URL, or set provider explicitly. Supported providers: %s.", strings.Join(s.providers.ProviderIDs(), ", "))
+}
+
+func providerDetails(selectedProvider string, supportedProviders []string, extras ...map[string]any) map[string]any {
+	details := map[string]any{
+		"provider":            selectedProvider,
+		"supported_providers": supportedProviders,
+	}
+	for _, extra := range extras {
+		for key, value := range extra {
+			details[key] = value
+		}
+	}
+	return details
 }
 
 func normalizeRun(providerID string, run *providers.Run, repository, resolvedRunURL string, jobs []providers.Job) domain.PipelineRun {

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -88,15 +88,21 @@ func (m *memoryAuditStore) Append(_ context.Context, event domain.AuditEvent) er
 
 type seamTestProvider struct {
 	expectedRepository string
+	providerID         string
+	runURL             string
 	listRuns           []providers.Run
 	run                *providers.Run
 	jobs               []providers.Job
 	parsedRepository   string
+	parsedRunURL       string
 	fetchedRepository  string
 	listedRepository   string
 }
 
 func (p *seamTestProvider) ProviderID() string {
+	if strings.TrimSpace(p.providerID) != "" {
+		return p.providerID
+	}
 	return "gitlab_ci"
 }
 
@@ -108,8 +114,23 @@ func (p *seamTestProvider) ParseRepository(repository string) (string, error) {
 	return repository, nil
 }
 
-func (p *seamTestProvider) ParseRunURL(string) (*providers.RunLocator, error) {
-	return nil, errors.New("unexpected ParseRunURL call")
+func (p *seamTestProvider) ParseRunURL(raw string) (*providers.RunLocator, error) {
+	if strings.TrimSpace(p.runURL) == "" {
+		return nil, errors.New("unexpected ParseRunURL call")
+	}
+	if raw != p.runURL {
+		return nil, errors.New("unexpected run url")
+	}
+	p.parsedRunURL = raw
+	runID := int64(55)
+	if p.run != nil && p.run.ID != 0 {
+		runID = p.run.ID
+	}
+	return &providers.RunLocator{
+		Repository: p.expectedRepository,
+		RunID:      runID,
+		RunURL:     raw,
+	}, nil
 }
 
 func (p *seamTestProvider) ParseCheckRunURL(string) (int64, error) {
@@ -190,7 +211,7 @@ func TestGetRunUsesProviderNativeRepositoryAndResolvedRunURL(t *testing.T) {
 	}
 	svc := &Service{
 		cfg:       testConfig(true),
-		provider:  provider,
+		providers: mustTestRegistry(t, provider),
 		audit:     &memoryAuditStore{},
 		telemetry: telemetry.NewCollector(""),
 		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -242,7 +263,7 @@ func TestGetRunRepositoryOnlyFallsBackToResolvedRunURL(t *testing.T) {
 	}
 	svc := &Service{
 		cfg:       testConfig(true),
-		provider:  provider,
+		providers: mustTestRegistry(t, provider),
 		audit:     &memoryAuditStore{},
 		telemetry: telemetry.NewCollector(""),
 		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -261,6 +282,110 @@ func TestGetRunRepositoryOnlyFallsBackToResolvedRunURL(t *testing.T) {
 	}
 	if run.RunURL != "https://ci.example/group/subgroup/project/runs/89" {
 		t.Fatalf("expected resolved run url fallback, got %q", run.RunURL)
+	}
+}
+
+func TestGetRunUsesExplicitProviderSelection(t *testing.T) {
+	githubProvider := githubapi.NewProviderAdapter(&mockGitHubClient{
+		getRunFn: func(context.Context, string, string, int64) (*githubapi.WorkflowRun, error) {
+			t.Fatal("expected non-default provider for explicit provider selection")
+			return nil, nil
+		},
+	}, "https://api.github.com")
+
+	gitLabProvider := &seamTestProvider{
+		providerID:         "gitlab_ci",
+		expectedRepository: "group/subgroup/project",
+		run: &providers.Run{
+			ID:         55,
+			Name:       "pipeline",
+			HeadSHA:    "abc123",
+			Conclusion: "failure",
+		},
+		jobs: []providers.Job{{Name: "unit", Conclusion: "failure"}},
+	}
+
+	svc := &Service{
+		cfg:       testConfig(true),
+		providers: mustTestRegistry(t, githubProvider, gitLabProvider),
+		audit:     &memoryAuditStore{},
+		telemetry: telemetry.NewCollector(""),
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:       time.Now,
+	}
+
+	run, toolErr := svc.GetRun(context.Background(), RunReference{Provider: "gitlab_ci", Repository: "group/subgroup/project", RunID: 55})
+	if toolErr != nil {
+		t.Fatalf("unexpected tool error: %+v", toolErr)
+	}
+	if run == nil {
+		t.Fatal("expected run")
+	}
+	if run.Provider != "gitlab_ci" {
+		t.Fatalf("expected gitlab_ci provider, got %q", run.Provider)
+	}
+	if gitLabProvider.fetchedRepository != "group/subgroup/project" {
+		t.Fatalf("expected explicit provider repository lookup, got %q", gitLabProvider.fetchedRepository)
+	}
+}
+
+func TestGetRunInfersProviderFromRunURL(t *testing.T) {
+	githubProvider := githubapi.NewProviderAdapter(&mockGitHubClient{
+		getRunFn: func(context.Context, string, string, int64) (*githubapi.WorkflowRun, error) {
+			t.Fatal("expected run_url inference to avoid GitHub provider")
+			return nil, nil
+		},
+	}, "https://api.github.com")
+
+	gitLabProvider := &seamTestProvider{
+		providerID:         "gitlab_ci",
+		expectedRepository: "group/subgroup/project",
+		runURL:             "https://ci.example/group/subgroup/project/runs/77",
+		run: &providers.Run{
+			ID:         77,
+			Name:       "pipeline",
+			HeadSHA:    "abc123",
+			Conclusion: "failure",
+		},
+		jobs: []providers.Job{{Name: "unit", Conclusion: "failure"}},
+	}
+
+	svc := &Service{
+		cfg:       testConfig(true),
+		providers: mustTestRegistry(t, githubProvider, gitLabProvider),
+		audit:     &memoryAuditStore{},
+		telemetry: telemetry.NewCollector(""),
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:       time.Now,
+	}
+
+	run, toolErr := svc.GetRun(context.Background(), RunReference{RunURL: "https://ci.example/group/subgroup/project/runs/77"})
+	if toolErr != nil {
+		t.Fatalf("unexpected tool error: %+v", toolErr)
+	}
+	if run == nil {
+		t.Fatal("expected run")
+	}
+	if gitLabProvider.parsedRunURL != "https://ci.example/group/subgroup/project/runs/77" {
+		t.Fatalf("expected provider inference to parse run url, got %q", gitLabProvider.parsedRunURL)
+	}
+	if run.Provider != "gitlab_ci" {
+		t.Fatalf("expected gitlab_ci provider, got %q", run.Provider)
+	}
+}
+
+func TestAnalyzeFlakyTestsRejectsUnknownProvider(t *testing.T) {
+	svc := newTestService(&mockGitHubClient{}, true)
+
+	_, toolErr := svc.AnalyzeFlakyTests(context.Background(), "circleci", "acme/app", 14, "")
+	if toolErr == nil {
+		t.Fatal("expected tool error")
+	}
+	if toolErr.Code != domain.ErrorCodeInvalidInput {
+		t.Fatalf("expected %s, got %s", domain.ErrorCodeInvalidInput, toolErr.Code)
+	}
+	if !strings.Contains(toolErr.Message, "unsupported provider") {
+		t.Fatalf("unexpected message: %q", toolErr.Message)
 	}
 }
 
@@ -345,7 +470,7 @@ func TestAnalyzeFlakyTests(t *testing.T) {
 
 	svc := newTestService(mock, false)
 	svc.now = func() time.Time { return now }
-	report, toolErr := svc.AnalyzeFlakyTests(context.Background(), "acme/app", 14, "")
+	report, toolErr := svc.AnalyzeFlakyTests(context.Background(), "", "acme/app", 14, "")
 	if toolErr != nil {
 		t.Fatalf("unexpected error: %+v", toolErr)
 	}
@@ -371,18 +496,18 @@ func TestRerunRequiresReasonAndAudit(t *testing.T) {
 
 	svc := &Service{
 		cfg:       cfg,
-		provider:  githubapi.NewProviderAdapter(mock, cfg.GitHubAPIBaseURL),
+		providers: mustTestRegistry(t, githubapi.NewProviderAdapter(mock, cfg.GitHubAPIBaseURL)),
 		audit:     auditStore,
 		telemetry: telemetry.NewCollector(""),
 		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
 		now:       time.Now,
 	}
 
-	if _, err := svc.Rerun(context.Background(), "acme/app", 99, true, ""); err == nil {
+	if _, err := svc.Rerun(context.Background(), "", "acme/app", 99, true, ""); err == nil {
 		t.Fatal("expected reason validation error")
 	}
 
-	result, toolErr := svc.Rerun(context.Background(), "acme/app", 99, true, "retry flaky network failure")
+	result, toolErr := svc.Rerun(context.Background(), "", "acme/app", 99, true, "retry flaky network failure")
 	if toolErr != nil {
 		t.Fatalf("unexpected rerun error: %+v", toolErr)
 	}
@@ -418,7 +543,7 @@ func TestComparePerformance(t *testing.T) {
 	svc := newTestService(mock, false)
 	from := now.Add(-1 * time.Hour)
 	to := now
-	snapshot, toolErr := svc.ComparePerformance(context.Background(), "acme/app", "ci", from, to)
+	snapshot, toolErr := svc.ComparePerformance(context.Background(), "", "acme/app", "ci", from, to)
 	if toolErr != nil {
 		t.Fatalf("unexpected error: %+v", toolErr)
 	}
@@ -710,11 +835,32 @@ func TestDiagnoseFailureRepositoryOnlyReturnsHelpfulErrorWhenNoFailuresExist(t *
 	}
 }
 
+func mustTestRegistry(t *testing.T, adapters ...providers.Adapter) *providers.Registry {
+	t.Helper()
+
+	registry, err := buildTestRegistry(adapters...)
+	if err != nil {
+		t.Fatalf("providers.NewRegistry() error = %v", err)
+	}
+	return registry
+}
+
+func buildTestRegistry(adapters ...providers.Adapter) (*providers.Registry, error) {
+	if len(adapters) == 0 {
+		return nil, errors.New("expected at least one provider adapter")
+	}
+	return providers.NewRegistry(adapters[0].ProviderID(), adapters...)
+}
+
 func newTestService(client *mockGitHubClient, disableMutations bool) *Service {
 	cfg := testConfig(disableMutations)
+	registry, err := buildTestRegistry(githubapi.NewProviderAdapter(client, cfg.GitHubAPIBaseURL))
+	if err != nil {
+		panic(err)
+	}
 	return &Service{
 		cfg:       cfg,
-		provider:  githubapi.NewProviderAdapter(client, cfg.GitHubAPIBaseURL),
+		providers: registry,
 		audit:     &memoryAuditStore{},
 		telemetry: telemetry.NewCollector(""),
 		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),

--- a/tools/acceptance_test.go
+++ b/tools/acceptance_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keithdoyle9/pipeline-mcp/config"
 	"github.com/keithdoyle9/pipeline-mcp/internal/domain"
 	"github.com/keithdoyle9/pipeline-mcp/internal/githubapi"
+	"github.com/keithdoyle9/pipeline-mcp/internal/providers"
 	"github.com/keithdoyle9/pipeline-mcp/internal/service"
 	"github.com/keithdoyle9/pipeline-mcp/internal/telemetry"
 )
@@ -309,8 +310,18 @@ func newAcceptanceDependencies(t *testing.T, client *acceptanceGitHubClient, aud
 	}
 
 	return Dependencies{
-		Service:   service.New(cfg, githubapi.NewProviderAdapter(client, cfg.GitHubAPIBaseURL), auditStore, collector, logger),
+		Service:   service.New(cfg, mustAcceptanceRegistry(t, githubapi.NewProviderAdapter(client, cfg.GitHubAPIBaseURL)), auditStore, collector, logger),
 		Telemetry: collector,
 		Logger:    logger,
 	}
+}
+
+func mustAcceptanceRegistry(t *testing.T, adapter providers.Adapter) *providers.Registry {
+	t.Helper()
+
+	registry, err := providers.NewRegistry(adapter.ProviderID(), adapter)
+	if err != nil {
+		t.Fatalf("providers.NewRegistry() error = %v", err)
+	}
+	return registry
 }

--- a/tools/registry.go
+++ b/tools/registry.go
@@ -19,32 +19,37 @@ type Dependencies struct {
 }
 
 type RunLocatorInput struct {
+	Provider   string `json:"provider,omitempty" jsonschema:"Optional pipeline provider identifier; defaults to github_actions when omitted"`
 	RunURL     string `json:"run_url,omitempty" jsonschema:"Pipeline run URL for the active provider"`
-	RunID      int64  `json:"run_id,omitempty" jsonschema:"GitHub Actions run id"`
+	RunID      int64  `json:"run_id,omitempty" jsonschema:"Pipeline run id accepted by the selected provider"`
 	Repository string `json:"repository,omitempty" jsonschema:"Repository identifier accepted by the active provider; required when using run_id, or accepted alone to resolve the latest failed run"`
 }
 
 type DiagnoseFailureInput struct {
+	Provider    string `json:"provider,omitempty" jsonschema:"Optional pipeline provider identifier; defaults to github_actions when omitted"`
 	RunURL      string `json:"run_url,omitempty" jsonschema:"Pipeline run URL for the active provider"`
-	RunID       int64  `json:"run_id,omitempty" jsonschema:"GitHub Actions run id"`
+	RunID       int64  `json:"run_id,omitempty" jsonschema:"Pipeline run id accepted by the selected provider"`
 	Repository  string `json:"repository,omitempty" jsonschema:"Repository identifier accepted by the active provider; required when using run_id, or accepted alone to diagnose the latest failed run"`
 	MaxLogBytes int64  `json:"max_log_bytes,omitempty" jsonschema:"Max bytes of logs to ingest for analysis"`
 }
 
 type AnalyzeFlakyTestsInput struct {
+	Provider     string `json:"provider,omitempty" jsonschema:"Optional pipeline provider identifier; defaults to github_actions when omitted"`
 	Repository   string `json:"repository" jsonschema:"Repository identifier accepted by the active provider"`
 	LookbackDays int    `json:"lookback_days,omitempty" jsonschema:"How many days of run history to inspect"`
 	Workflow     string `json:"workflow,omitempty" jsonschema:"Optional workflow name filter"`
 }
 
 type RerunInput struct {
+	Provider       string `json:"provider,omitempty" jsonschema:"Optional pipeline provider identifier; defaults to github_actions when omitted"`
 	Repository     string `json:"repository" jsonschema:"Repository identifier accepted by the active provider"`
-	RunID          int64  `json:"run_id" jsonschema:"GitHub Actions run id"`
+	RunID          int64  `json:"run_id" jsonschema:"Pipeline run id accepted by the selected provider"`
 	FailedJobsOnly bool   `json:"failed_jobs_only" jsonschema:"If true reruns only failed jobs"`
 	Reason         string `json:"reason" jsonschema:"Reason for rerun to persist in audit log"`
 }
 
 type ComparePerformanceInput struct {
+	Provider   string `json:"provider,omitempty" jsonschema:"Optional pipeline provider identifier; defaults to github_actions when omitted"`
 	Repository string `json:"repository" jsonschema:"Repository identifier accepted by the active provider"`
 	Workflow   string `json:"workflow" jsonschema:"Workflow name to compare"`
 	From       string `json:"from" jsonschema:"Current window start (RFC3339 or YYYY-MM-DD)"`
@@ -80,33 +85,33 @@ type ComparePerformanceOutput struct {
 func Register(server *mcp.Server, deps Dependencies) {
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "pipeline.get_run",
-		Description: "Fetch normalized metadata for a GitHub Actions workflow run by run_url, by run_id plus repository, or by repository alone for the latest failed run.",
+		Description: "Fetch normalized metadata for a pipeline run by run_url, by run_id plus repository, or by repository alone for the latest failed run. Defaults to GitHub Actions when provider is omitted.",
 	}, deps.getRun)
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "pipeline.diagnose_failure",
-		Description: "Diagnose failed GitHub Actions runs and return ranked fix recommendations with evidence. Accepts run_url, run_id plus repository, or repository alone for the latest failed run.",
+		Description: "Diagnose failed pipeline runs and return ranked fix recommendations with evidence. Accepts run_url, run_id plus repository, or repository alone for the latest failed run. Defaults to GitHub Actions when provider is omitted.",
 	}, deps.diagnoseFailure)
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "pipeline.analyze_flaky_tests",
-		Description: "Analyze recent failed runs to identify likely flaky tests with confidence and recency.",
+		Description: "Analyze recent failed runs to identify likely flaky tests with confidence and recency. Defaults to GitHub Actions when provider is omitted.",
 	}, deps.analyzeFlakyTests)
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "pipeline.rerun",
-		Description: "Trigger controlled reruns for GitHub Actions with explicit reason and audit logging.",
+		Description: "Trigger controlled reruns for the selected provider with explicit reason and audit logging. Defaults to GitHub Actions when provider is omitted.",
 	}, deps.rerun)
 
 	mcp.AddTool(server, &mcp.Tool{
 		Name:        "pipeline.compare_performance",
-		Description: "Compare workflow performance against the immediately preceding baseline window.",
+		Description: "Compare workflow performance against the immediately preceding baseline window. Defaults to GitHub Actions when provider is omitted.",
 	}, deps.comparePerformance)
 }
 
 func (d Dependencies) getRun(ctx context.Context, _ *mcp.CallToolRequest, input RunLocatorInput) (*mcp.CallToolResult, GetRunOutput, error) {
 	start := time.Now()
-	run, toolErr := d.Service.GetRun(ctx, service.RunReference{RunURL: input.RunURL, RunID: input.RunID, Repository: input.Repository})
+	run, toolErr := d.Service.GetRun(ctx, service.RunReference{Provider: input.Provider, RunURL: input.RunURL, RunID: input.RunID, Repository: input.Repository})
 	if toolErr != nil {
 		d.observe("pipeline.get_run", start, false, nil)
 		return toolErrorResult(toolErr), GetRunOutput{Error: toolErr}, nil
@@ -117,7 +122,7 @@ func (d Dependencies) getRun(ctx context.Context, _ *mcp.CallToolRequest, input 
 
 func (d Dependencies) diagnoseFailure(ctx context.Context, _ *mcp.CallToolRequest, input DiagnoseFailureInput) (*mcp.CallToolResult, DiagnoseFailureOutput, error) {
 	start := time.Now()
-	diagnostic, recommendations, toolErr := d.Service.DiagnoseFailure(ctx, service.RunReference{RunURL: input.RunURL, RunID: input.RunID, Repository: input.Repository}, input.MaxLogBytes)
+	diagnostic, recommendations, toolErr := d.Service.DiagnoseFailure(ctx, service.RunReference{Provider: input.Provider, RunURL: input.RunURL, RunID: input.RunID, Repository: input.Repository}, input.MaxLogBytes)
 	if toolErr != nil {
 		d.observe("pipeline.diagnose_failure", start, false, nil)
 		return toolErrorResult(toolErr), DiagnoseFailureOutput{Error: toolErr}, nil
@@ -129,7 +134,7 @@ func (d Dependencies) diagnoseFailure(ctx context.Context, _ *mcp.CallToolReques
 
 func (d Dependencies) analyzeFlakyTests(ctx context.Context, _ *mcp.CallToolRequest, input AnalyzeFlakyTestsInput) (*mcp.CallToolResult, AnalyzeFlakyTestsOutput, error) {
 	start := time.Now()
-	report, toolErr := d.Service.AnalyzeFlakyTests(ctx, input.Repository, input.LookbackDays, input.Workflow)
+	report, toolErr := d.Service.AnalyzeFlakyTests(ctx, input.Provider, input.Repository, input.LookbackDays, input.Workflow)
 	if toolErr != nil {
 		d.observe("pipeline.analyze_flaky_tests", start, false, nil)
 		return toolErrorResult(toolErr), AnalyzeFlakyTestsOutput{Error: toolErr}, nil
@@ -145,7 +150,7 @@ func (d Dependencies) analyzeFlakyTests(ctx context.Context, _ *mcp.CallToolRequ
 
 func (d Dependencies) rerun(ctx context.Context, _ *mcp.CallToolRequest, input RerunInput) (*mcp.CallToolResult, RerunOutput, error) {
 	start := time.Now()
-	result, toolErr := d.Service.Rerun(ctx, input.Repository, input.RunID, input.FailedJobsOnly, input.Reason)
+	result, toolErr := d.Service.Rerun(ctx, input.Provider, input.Repository, input.RunID, input.FailedJobsOnly, input.Reason)
 	if toolErr != nil {
 		d.observe("pipeline.rerun", start, false, nil)
 		return toolErrorResult(toolErr), RerunOutput{Error: toolErr}, nil
@@ -169,7 +174,7 @@ func (d Dependencies) comparePerformance(ctx context.Context, _ *mcp.CallToolReq
 		return toolErrorResult(toolErr), ComparePerformanceOutput{Error: toolErr}, nil
 	}
 
-	snapshot, toolErr := d.Service.ComparePerformance(ctx, input.Repository, input.Workflow, from, to)
+	snapshot, toolErr := d.Service.ComparePerformance(ctx, input.Provider, input.Repository, input.Workflow, from, to)
 	if toolErr != nil {
 		d.observe("pipeline.compare_performance", start, false, nil)
 		return toolErrorResult(toolErr), ComparePerformanceOutput{Error: toolErr}, nil

--- a/tools/registry_test.go
+++ b/tools/registry_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keithdoyle9/pipeline-mcp/config"
 	"github.com/keithdoyle9/pipeline-mcp/internal/audit"
 	"github.com/keithdoyle9/pipeline-mcp/internal/githubapi"
+	"github.com/keithdoyle9/pipeline-mcp/internal/providers"
 	"github.com/keithdoyle9/pipeline-mcp/internal/service"
 	"github.com/keithdoyle9/pipeline-mcp/internal/telemetry"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -45,9 +46,14 @@ func (noopGitHubClient) Rerun(context.Context, string, string, int64, bool) erro
 
 func TestRegisterExposesFiveTools(t *testing.T) {
 	server := mcp.NewServer(&mcp.Implementation{Name: "pipeline-mcp-test", Version: "test"}, &mcp.ServerOptions{Capabilities: &mcp.ServerCapabilities{Tools: &mcp.ToolCapabilities{}}})
+	adapter := githubapi.NewProviderAdapter(noopGitHubClient{}, "https://api.github.com")
+	registry, err := providers.NewRegistry(adapter.ProviderID(), adapter)
+	if err != nil {
+		t.Fatalf("providers.NewRegistry() error = %v", err)
+	}
 	svc := service.New(
 		&config.Config{GitHubAPIBaseURL: "https://api.github.com", DisableMutations: true, MaxLogBytes: 1024, DefaultLookbackDays: 14, MaxHistoricalRuns: 100},
-		githubapi.NewProviderAdapter(noopGitHubClient{}, "https://api.github.com"),
+		registry,
 		audit.NewJSONLStore(t.TempDir()+"/audit.jsonl", ""),
 		telemetry.NewCollector(""),
 		slog.New(slog.NewTextHandler(io.Discard, nil)),


### PR DESCRIPTION
## Summary

- Implement provider-aware routing with a provider registry that can resolve the adapter explicitly or infer it from `run_url`.
- Preserve GitHub backward compatibility by keeping `github_actions` as the default when `provider` is omitted.
- Thread the optional `provider` input through the MCP tool contracts, service layer, bootstrap wiring, tests, and README.

Closes #11.

## Validation

- [x] `GOCACHE=$(pwd)/.gocache go test ./...`
- [ ] `go run ./cmd/benchmark` (not needed: diagnosis logic and benchmark fixtures were unchanged)
- [x] `GOCACHE=$(pwd)/.gocache go build ./...`

## Config Impact

- None. GitHub remains the default provider when `provider` is omitted.
- No new environment variables or operator settings are required for this slice.
- No follow-up GitHub settings changes are required.

## Sample Request/Response

Request with backward-compatible default routing:

```json
{
  "repository": "acme/app"
}
```

Request with explicit provider selection:

```json
{
  "provider": "github_actions",
  "repository": "acme/app",
  "run_id": 144
}
```

Example response shape:

```json
{
  "run": {
    "provider": "github_actions",
    "repository": "acme/app",
    "run_id": 144,
    "run_url": "https://github.com/acme/app/actions/runs/144"
  }
}
```

## Checklist

- [x] Tests were added or updated for behavior changes.
- [x] Documentation was updated for user-facing or operator-facing changes.
- [x] AI-assisted commits include `AI-assisted-by` trailers with the tool and model used.
- [x] No secrets or sensitive logs were added.
- [x] Follow-up GitHub settings changes are called out, if any.
