### PR TITLE
Add GitLab CI provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![CodeQL](https://github.com/keithdoyle9/pipeline-mcp/actions/workflows/codeql.yml/badge.svg)](https://github.com/keithdoyle9/pipeline-mcp/actions/workflows/codeql.yml)
 [![License](https://img.shields.io/github/license/keithdoyle9/pipeline-mcp)](LICENSE)
 
-`pipeline-mcp` is a Go MCP server for CI/CD diagnosis and remediation workflows. GitHub Actions remains the default provider, and the tool inputs now accept an optional `provider` field for provider-aware routing.
+`pipeline-mcp` is a Go MCP server for CI/CD diagnosis and remediation workflows. GitHub Actions remains the default provider, and the tool inputs accept an optional `provider` field for provider-aware routing across GitHub Actions and GitLab CI.
 
 ## MVP Capabilities
 
@@ -14,6 +14,7 @@
 - `pipeline.rerun`: trigger controlled reruns with explicit reason and audit logging.
 - `pipeline.compare_performance`: compare current window metrics against an immediately preceding baseline window.
 - All tools accept an optional `provider` input; omitting it preserves GitHub Actions as the default.
+- `provider="gitlab_ci"` enables GitLab CI support for read tools plus failed-job reruns.
 
 ## Open Source Defaults
 
@@ -36,6 +37,7 @@ for the full policy and examples.
 
 - `cmd/pipeline-mcp`: server entrypoint.
 - `internal/githubapi`: GitHub Actions adapter (run metadata, jobs, logs, reruns, retries/backoff).
+- `internal/gitlabapi`: GitLab CI adapter (pipeline metadata, jobs, logs, retries/backoff).
 - `internal/analysis`: redaction, diagnosis heuristics, flaky analysis, performance aggregation.
 - `internal/service`: orchestration, validation, tool error mapping.
 - `internal/audit`: persistent JSONL audit events for mutation tools.
@@ -46,6 +48,8 @@ for the full policy and examples.
 
 - GitHub token with `actions:read` for read tools
 - Optional write token with `actions:write` for `pipeline.rerun`
+- Optional GitLab token with `read_api` for read tools
+- Optional GitLab write token with `api` for GitLab failed-job reruns
 - Go `1.26+` only if you are building from source
 
 ## Configuration
@@ -57,8 +61,11 @@ Environment variables:
 - `LOG_LEVEL` (`debug|info|warn|error`, default: `info`)
 - `GITHUB_API_BASE_URL` (default: `https://api.github.com`)
 - `GITHUB_READ_TOKEN` (recommended)
-- `GITHUB_WRITE_TOKEN` (required when `DISABLE_MUTATIONS=false`; no shared fallback)
+- `GITHUB_WRITE_TOKEN` (optional provider-specific write token; no shared fallback)
 - `GITHUB_TOKEN` or `GH_TOKEN` can be used as fallback for `GITHUB_READ_TOKEN`
+- `GITLAB_API_BASE_URL` (default: `https://gitlab.com/api/v4`)
+- `GITLAB_READ_TOKEN` (optional; recommended for private projects)
+- `GITLAB_WRITE_TOKEN` (optional provider-specific write token used by `pipeline.rerun` when `provider="gitlab_ci"`)
 - `DISABLE_MUTATIONS` (default: `true`)
 - `AUDIT_LOG_PATH` (default: `var/audit-events.jsonl`)
 - `AUDIT_SIGNING_KEY` (optional HMAC key for tamper-evident audit signatures)
@@ -73,6 +80,8 @@ Environment variables:
 When `AUDIT_SIGNING_KEY` is unset, audit entries omit the `signature` field rather than emitting a misleading unhashed digest.
 
 For least-privilege token setup and release operations, see [docs/operator-guide.md](docs/operator-guide.md).
+
+`DISABLE_MUTATIONS=false` no longer requires a write token at startup. Each provider enforces its own explicit write token only when `pipeline.rerun` is invoked.
 
 ## Install
 
@@ -138,6 +147,7 @@ Repository-only shortcut examples:
 Use pipeline.get_run with repository="owner/repo" to inspect the latest failed run.
 Use pipeline.diagnose_failure with repository="owner/repo" to diagnose the latest failed run.
 Add provider="github_actions" explicitly only when you need to override default routing behavior.
+Use provider="gitlab_ci" with repository="group/subgroup/project" for GitLab CI runs.
 ```
 
 ## GitHub Repository Protections

--- a/cmd/pipeline-mcp/main.go
+++ b/cmd/pipeline-mcp/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/keithdoyle9/pipeline-mcp/config"
 	"github.com/keithdoyle9/pipeline-mcp/internal/audit"
 	"github.com/keithdoyle9/pipeline-mcp/internal/githubapi"
+	"github.com/keithdoyle9/pipeline-mcp/internal/gitlabapi"
 	"github.com/keithdoyle9/pipeline-mcp/internal/providers"
 	"github.com/keithdoyle9/pipeline-mcp/internal/service"
 	"github.com/keithdoyle9/pipeline-mcp/internal/telemetry"
@@ -38,7 +39,9 @@ func run() error {
 	telemetryCollector := telemetry.NewCollector(cfg.MetricsExportPath)
 	ghClient := githubapi.NewClient(cfg.GitHubAPIBaseURL, cfg.GitHubReadToken, cfg.GitHubWriteToken, cfg.UserAgent, cfg.HTTPTimeout)
 	ghProvider := githubapi.NewProviderAdapter(ghClient, cfg.GitHubAPIBaseURL)
-	providerRegistry, err := providers.NewRegistry(ghProvider.ProviderID(), ghProvider)
+	glClient := gitlabapi.NewClient(cfg.GitLabAPIBaseURL, cfg.GitLabReadToken, cfg.GitLabWriteToken, cfg.UserAgent, cfg.HTTPTimeout)
+	glProvider := gitlabapi.NewProviderAdapter(glClient, cfg.GitLabAPIBaseURL)
+	providerRegistry, err := providers.NewRegistry(ghProvider.ProviderID(), ghProvider, glProvider)
 	if err != nil {
 		return fmt.Errorf("build provider registry: %w", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -19,6 +19,9 @@ type Config struct {
 	GitHubAPIBaseURL    string
 	GitHubReadToken     string
 	GitHubWriteToken    string
+	GitLabAPIBaseURL    string
+	GitLabReadToken     string
+	GitLabWriteToken    string
 	DisableMutations    bool
 	AuditLogPath        string
 	AuditSigningKey     string
@@ -71,6 +74,9 @@ func Load() (*Config, error) {
 		GitHubAPIBaseURL:    strings.TrimRight(getEnv("GITHUB_API_BASE_URL", "https://api.github.com"), "/"),
 		GitHubReadToken:     firstEnv("GITHUB_READ_TOKEN", "GITHUB_TOKEN", "GH_TOKEN"),
 		GitHubWriteToken:    strings.TrimSpace(os.Getenv("GITHUB_WRITE_TOKEN")),
+		GitLabAPIBaseURL:    strings.TrimRight(getEnv("GITLAB_API_BASE_URL", "https://gitlab.com/api/v4"), "/"),
+		GitLabReadToken:     strings.TrimSpace(os.Getenv("GITLAB_READ_TOKEN")),
+		GitLabWriteToken:    strings.TrimSpace(os.Getenv("GITLAB_WRITE_TOKEN")),
 		DisableMutations:    disableMutations,
 		AuditLogPath:        getEnv("AUDIT_LOG_PATH", "var/audit-events.jsonl"),
 		AuditSigningKey:     strings.TrimSpace(os.Getenv("AUDIT_SIGNING_KEY")),
@@ -174,19 +180,26 @@ func validate(cfg *Config) error {
 	if cfg.HTTPTimeout <= 0 {
 		return fmt.Errorf("HTTP_TIMEOUT_SECONDS must be greater than zero")
 	}
-	if !cfg.DisableMutations && strings.TrimSpace(cfg.GitHubWriteToken) == "" {
-		return fmt.Errorf("GITHUB_WRITE_TOKEN is required when DISABLE_MUTATIONS=false")
+	if err := validateBaseURL("GITHUB_API_BASE_URL", cfg.GitHubAPIBaseURL); err != nil {
+		return err
+	}
+	if err := validateBaseURL("GITLAB_API_BASE_URL", cfg.GitLabAPIBaseURL); err != nil {
+		return err
 	}
 
-	parsedURL, err := url.Parse(cfg.GitHubAPIBaseURL)
+	return nil
+}
+
+func validateBaseURL(name, raw string) error {
+	parsedURL, err := url.Parse(raw)
 	if err != nil {
-		return fmt.Errorf("parse GITHUB_API_BASE_URL: %w", err)
+		return fmt.Errorf("parse %s: %w", name, err)
 	}
 	if parsedURL.Scheme != "https" && parsedURL.Scheme != "http" {
-		return fmt.Errorf("GITHUB_API_BASE_URL must use http or https")
+		return fmt.Errorf("%s must use http or https", name)
 	}
 	if strings.TrimSpace(parsedURL.Host) == "" {
-		return fmt.Errorf("GITHUB_API_BASE_URL must include a host")
+		return fmt.Errorf("%s must include a host", name)
 	}
 
 	return nil

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -103,6 +103,21 @@ func TestLoadAllowsMutationsWhenExplicitWriteTokenIsSet(t *testing.T) {
 	}
 }
 
+func TestLoadAllowsMutationsWithoutProviderWriteToken(t *testing.T) {
+	t.Setenv("DISABLE_MUTATIONS", "false")
+	t.Setenv("GITHUB_WRITE_TOKEN", "")
+	t.Setenv("GITLAB_WRITE_TOKEN", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if cfg.DisableMutations {
+		t.Fatal("expected mutations to be enabled")
+	}
+}
+
 func TestLoadRejectsInvalidRuntimeConfiguration(t *testing.T) {
 	testCases := []struct {
 		name    string
@@ -130,16 +145,6 @@ func TestLoadRejectsInvalidRuntimeConfiguration(t *testing.T) {
 			wantErr: "HTTP_TIMEOUT_SECONDS must be greater than zero",
 		},
 		{
-			name: "mutations enabled without write token",
-			env: map[string]string{
-				"DISABLE_MUTATIONS":  "false",
-				"GITHUB_WRITE_TOKEN": "",
-				"GITHUB_TOKEN":       "",
-				"GH_TOKEN":           "",
-			},
-			wantErr: "GITHUB_WRITE_TOKEN is required when DISABLE_MUTATIONS=false",
-		},
-		{
 			name:    "invalid api base url scheme",
 			env:     map[string]string{"GITHUB_API_BASE_URL": "ssh://github.example.com"},
 			wantErr: "GITHUB_API_BASE_URL must use http or https",
@@ -148,6 +153,16 @@ func TestLoadRejectsInvalidRuntimeConfiguration(t *testing.T) {
 			name:    "missing api base url host",
 			env:     map[string]string{"GITHUB_API_BASE_URL": "https:///"},
 			wantErr: "GITHUB_API_BASE_URL must include a host",
+		},
+		{
+			name:    "invalid gitlab api base url scheme",
+			env:     map[string]string{"GITLAB_API_BASE_URL": "ssh://gitlab.example.com/api/v4"},
+			wantErr: "GITLAB_API_BASE_URL must use http or https",
+		},
+		{
+			name:    "missing gitlab api base url host",
+			env:     map[string]string{"GITLAB_API_BASE_URL": "https:///api/v4"},
+			wantErr: "GITLAB_API_BASE_URL must include a host",
 		},
 	}
 

--- a/docs/operator-guide.md
+++ b/docs/operator-guide.md
@@ -17,6 +17,21 @@ Operational guidance:
 - `GITHUB_WRITE_TOKEN` must be explicit whenever reruns are enabled; `GITHUB_TOKEN` and `GH_TOKEN` are read-token fallbacks only.
 - Read tools may work against public repositories without a token, but rate limits and private-repository access will be worse.
 
+## GitLab Credentials
+
+| Variable | Required | Minimum access | Used by |
+| --- | --- | --- | --- |
+| `GITLAB_READ_TOKEN` | Optional | `read_api` | `pipeline.get_run`, `pipeline.diagnose_failure`, `pipeline.analyze_flaky_tests`, `pipeline.compare_performance` |
+| `GITLAB_WRITE_TOKEN` | Only when `DISABLE_MUTATIONS=false` and GitLab reruns are allowed | `api` | `pipeline.rerun` with `provider="gitlab_ci"` |
+| `GITLAB_API_BASE_URL` | Optional | N/A | Selects `gitlab.com` or one self-managed GitLab instance per server process |
+
+Operational guidance:
+
+- Set `GITLAB_API_BASE_URL` to `https://gitlab.example.com/api/v4` for self-managed instances.
+- Prefer separate read and write tokens so read-only hosts do not carry write credentials.
+- GitLab read tools may work without a token on public projects, but private-project access and rate limits will be worse.
+- GitLab reruns only support `failed_jobs_only=true`; full pipeline reruns are rejected as invalid input.
+
 ## Runtime Modes
 
 ### Read-only default
@@ -24,16 +39,20 @@ Operational guidance:
 - `DISABLE_MUTATIONS=true`
 - Set `GITHUB_READ_TOKEN` with `actions:read`
 - Omit `GITHUB_WRITE_TOKEN`
+- Optionally set `GITLAB_READ_TOKEN` with `read_api`
+- Omit `GITLAB_WRITE_TOKEN`
 
 ### Controlled rerun mode
 
 - `DISABLE_MUTATIONS=false`
 - Set `GITHUB_READ_TOKEN` with `actions:read`
-- Set `GITHUB_WRITE_TOKEN` with `actions:write`
+- Set `GITHUB_WRITE_TOKEN` with `actions:write` only on hosts that should rerun GitHub workflows
+- Set `GITLAB_READ_TOKEN` with `read_api` if GitLab read access is needed
+- Set `GITLAB_WRITE_TOKEN` with `api` only on hosts that should retry GitLab pipelines
 - Set `AUDIT_LOG_PATH` to a persistent location
 - Set `AUDIT_SIGNING_KEY` when tamper-evident audit logs are required
 
-If `DISABLE_MUTATIONS=false` without a write token, startup now fails fast so the server does not advertise a broken mutation path.
+If `DISABLE_MUTATIONS=false` without a provider-specific write token, startup still succeeds, but `pipeline.rerun` returns `UNAUTHORIZED` for that provider until its explicit write token is configured.
 
 ## Filesystem Expectations
 
@@ -58,8 +77,9 @@ Current owners for the MVP release:
 
 - Provider outage triage: repository maintainer / release owner
 - GitHub token rotation: repository maintainer / repository admin
+- GitLab token rotation: repository maintainer / GitLab admin
 
 Minimum incident response steps:
 
-1. For GitHub API outages or rate-limit incidents, keep `DISABLE_MUTATIONS=true`, capture the error envelope, and monitor GitHub status before retrying.
+1. For GitHub or GitLab API outages or rate-limit incidents, keep `DISABLE_MUTATIONS=true`, capture the error envelope, and monitor provider status before retrying.
 2. For credential rotation, mint the replacement token with the same minimum scope, update the secret store, restart the server if needed, and validate read or rerun access with a known repository.

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -7,6 +7,8 @@ Use [docs/operator-guide.md](docs/operator-guide.md) for auth scope and operatio
 - [ ] `DISABLE_MUTATIONS` defaults to `true` in production config.
 - [ ] `GITHUB_READ_TOKEN` scope is limited to `actions:read`.
 - [ ] `GITHUB_WRITE_TOKEN` is only configured where rerun is allowed (`actions:write`).
+- [ ] `GITLAB_READ_TOKEN` scope is limited to `read_api` where GitLab access is required.
+- [ ] `GITLAB_WRITE_TOKEN` is only configured where GitLab failed-job retries are allowed (`api`).
 - [ ] Audit log path is persistent and protected.
 - [ ] `AUDIT_SIGNING_KEY` is configured anywhere tamper-evident audit logs are required.
 - [ ] Log redaction tests pass.
@@ -16,7 +18,7 @@ Use [docs/operator-guide.md](docs/operator-guide.md) for auth scope and operatio
 - [ ] `go test ./...` passes.
 - [ ] `./scripts/run-benchmarks.sh` runs successfully.
 - [ ] Metrics export path is configured and writable if telemetry export is required.
-- [ ] Retry/backoff behavior is validated against GitHub rate-limit and transient failures.
+- [ ] Retry/backoff behavior is validated against GitHub and GitLab rate-limit and transient failures.
 
 ## Operations
 
@@ -28,6 +30,7 @@ Use [docs/operator-guide.md](docs/operator-guide.md) for auth scope and operatio
 - [ ] Confirm prerelease tags such as `v0.1.0-rc.1` are published as GitHub prereleases.
 - [ ] Verify server startup and MCP tool listing with target client.
 - [ ] Confirm audit event format includes actor, reason, scope, timestamp, and outcome.
+- [ ] Confirm GitLab reruns are limited to `failed_jobs_only=true`.
 - [ ] Confirm runbook owners for provider outage and credential rotation in [docs/operator-guide.md](docs/operator-guide.md).
 
 ## Green Criteria

--- a/internal/domain/types.go
+++ b/internal/domain/types.go
@@ -4,6 +4,7 @@ import "time"
 
 const (
 	ProviderGitHub = "github_actions"
+	ProviderGitLab = "gitlab_ci"
 )
 
 const (

--- a/internal/gitlabapi/adapter.go
+++ b/internal/gitlabapi/adapter.go
@@ -1,0 +1,357 @@
+package gitlabapi
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/keithdoyle9/pipeline-mcp/internal/domain"
+	"github.com/keithdoyle9/pipeline-mcp/internal/providers"
+)
+
+type providerClient interface {
+	GetPipeline(ctx context.Context, projectPath string, pipelineID int64) (*Pipeline, error)
+	ListPipelineJobs(ctx context.Context, projectPath string, pipelineID int64) ([]Job, error)
+	DownloadJobTrace(ctx context.Context, projectPath string, jobID int64, maxBytes int64) (string, error)
+	ListProjectPipelines(ctx context.Context, projectPath string, opts ListPipelinesOptions, maxRuns int) ([]Pipeline, error)
+	RetryPipeline(ctx context.Context, projectPath string, pipelineID int64) error
+}
+
+type ProviderAdapter struct {
+	client     providerClient
+	apiBaseURL string
+}
+
+func NewProviderAdapter(client providerClient, apiBaseURL string) *ProviderAdapter {
+	return &ProviderAdapter{
+		client:     client,
+		apiBaseURL: strings.TrimRight(strings.TrimSpace(apiBaseURL), "/"),
+	}
+}
+
+func (a *ProviderAdapter) ProviderID() string {
+	return domain.ProviderGitLab
+}
+
+func (a *ProviderAdapter) ParseRepository(repository string) (string, error) {
+	return ParseProjectPath(repository)
+}
+
+func (a *ProviderAdapter) ParseRunURL(raw string) (*providers.RunLocator, error) {
+	locator, err := ParseRunURLForBase(raw, a.apiBaseURL)
+	if err != nil {
+		return nil, err
+	}
+	return &providers.RunLocator{
+		Repository: locator.Repository(),
+		RunID:      locator.RunID,
+		RunURL:     locator.RunURL,
+	}, nil
+}
+
+func (a *ProviderAdapter) ParseCheckRunURL(string) (int64, error) {
+	return 0, ErrCheckRunUnsupported
+}
+
+func (a *ProviderAdapter) RunURL(repository string, runID int64) string {
+	return RunURLForBase(repository, runID, a.apiBaseURL)
+}
+
+func (a *ProviderAdapter) GetRun(ctx context.Context, repository string, runID int64) (*providers.Run, error) {
+	pipeline, err := a.client.GetPipeline(ctx, repository, runID)
+	if err != nil || pipeline == nil {
+		return nil, err
+	}
+	return toProviderRun(pipeline), nil
+}
+
+func (a *ProviderAdapter) ListRunJobs(ctx context.Context, repository string, runID int64) ([]providers.Job, error) {
+	jobs, err := a.client.ListPipelineJobs(ctx, repository, runID)
+	if err != nil {
+		return nil, err
+	}
+	return toProviderJobs(jobs), nil
+}
+
+func (a *ProviderAdapter) DownloadRunLogs(ctx context.Context, repository string, runID int64, maxBytes int64) (string, error) {
+	jobs, err := a.client.ListPipelineJobs(ctx, repository, runID)
+	if err != nil {
+		return "", err
+	}
+	if len(jobs) == 0 {
+		return "", ErrLogsUnavailable
+	}
+
+	ordered := append([]Job(nil), jobs...)
+	sort.SliceStable(ordered, func(i, j int) bool {
+		ri := jobLogPriority(ordered[i])
+		rj := jobLogPriority(ordered[j])
+		if ri == rj {
+			return ordered[i].ID < ordered[j].ID
+		}
+		return ri < rj
+	})
+
+	if maxBytes <= 0 {
+		maxBytes = 1 << 20
+	}
+
+	var out bytes.Buffer
+	for _, job := range ordered {
+		trace, err := a.client.DownloadJobTrace(ctx, repository, job.ID, maxBytes)
+		if err != nil {
+			if errors.Is(err, ErrLogsUnavailable) {
+				continue
+			}
+			return "", err
+		}
+		trace = strings.TrimSpace(trace)
+		if trace == "" {
+			continue
+		}
+
+		chunk := fmt.Sprintf("=== job: %s (%d) ===\n%s\n", firstNonEmpty(job.Name, job.Stage, "job"), job.ID, trace)
+		if !appendLimited(&out, []byte(chunk), maxBytes) {
+			break
+		}
+	}
+
+	if out.Len() == 0 {
+		return "", ErrLogsUnavailable
+	}
+	return strings.TrimRight(out.String(), "\n"), nil
+}
+
+func (a *ProviderAdapter) ListRepositoryRuns(ctx context.Context, repository string, opts providers.ListRunsOptions, maxRuns int) ([]providers.Run, error) {
+	listOpts := ListPipelinesOptions{
+		PerPage: opts.PerPage,
+		Page:    opts.Page,
+		Status:  translatePipelineStatus(opts.Status),
+		OrderBy: "updated_at",
+		Sort:    "desc",
+	}
+	createdAfter, createdBefore, err := parseCreatedRange(opts.Created)
+	if err != nil {
+		return nil, err
+	}
+	listOpts.CreatedAfter = createdAfter
+	listOpts.CreatedBefore = createdBefore
+
+	pipelines, err := a.client.ListProjectPipelines(ctx, repository, listOpts, maxRuns)
+	if err != nil {
+		return nil, err
+	}
+	return toProviderRuns(pipelines), nil
+}
+
+func (a *ProviderAdapter) GetCheckRun(context.Context, string, int64) (*providers.CheckRun, error) {
+	return nil, nil
+}
+
+func (a *ProviderAdapter) GetCheckRunAnnotations(context.Context, string, int64) ([]providers.CheckRunAnnotation, error) {
+	return nil, nil
+}
+
+func (a *ProviderAdapter) ListDeploymentBranchPolicies(context.Context, string, string) ([]providers.BranchPolicy, error) {
+	return nil, nil
+}
+
+func (a *ProviderAdapter) Rerun(ctx context.Context, repository string, runID int64, failedJobsOnly bool) error {
+	if !failedJobsOnly {
+		return ErrFullRerunUnsupported
+	}
+	return a.client.RetryPipeline(ctx, repository, runID)
+}
+
+func (a *ProviderAdapter) IsLogsUnavailable(err error) bool {
+	return errors.Is(err, ErrLogsUnavailable)
+}
+
+func (a *ProviderAdapter) MapError(err error) *domain.ToolError {
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, ErrFullRerunUnsupported) {
+		return domain.NewToolError(
+			domain.ErrorCodeInvalidInput,
+			"GitLab rerun supports failed or canceled jobs only.",
+			"Set failed_jobs_only=true when provider=\"gitlab_ci\".",
+			false,
+			map[string]any{"error": err.Error()},
+		)
+	}
+	if errors.Is(err, ErrUnauthorized) || errors.Is(err, ErrWriteTokenRequired) {
+		return domain.NewToolError(
+			domain.ErrorCodeUnauthorized,
+			"GitLab API authorization failed.",
+			"Verify token scopes: read_api for read tools and api for rerun.",
+			false,
+			map[string]any{"error": err.Error()},
+		)
+	}
+	if errors.Is(err, ErrNotFound) {
+		return domain.NewToolError(
+			domain.ErrorCodeUnauthorized,
+			"Run not found or access denied.",
+			"Confirm the pipeline URL is correct and provide a token that can read this project.",
+			false,
+			map[string]any{"error": err.Error()},
+		)
+	}
+	if errors.Is(err, ErrRateLimited) {
+		return domain.NewToolError(
+			domain.ErrorCodeRateLimited,
+			"GitLab API rate limit exceeded.",
+			"Retry after backoff or increase API quota/token capacity.",
+			true,
+			map[string]any{"error": err.Error()},
+		)
+	}
+	if errors.Is(err, ErrLogsUnavailable) {
+		return domain.NewToolError(
+			domain.ErrorCodeLogUnavailable,
+			"Run logs are unavailable.",
+			"Check project permissions and job log retention settings.",
+			true,
+			map[string]any{"error": err.Error()},
+		)
+	}
+	if errors.Is(err, ErrProviderUnavailable) {
+		return domain.NewToolError(
+			domain.ErrorCodeProviderUnavailable,
+			"GitLab API is unavailable.",
+			"Retry with exponential backoff and check provider status.",
+			true,
+			map[string]any{"error": err.Error()},
+		)
+	}
+	return domain.NewToolError(domain.ErrorCodeInternal, "Unexpected internal error.", "Check server logs and retry.", true, map[string]any{"error": err.Error()})
+}
+
+func toProviderRun(pipeline *Pipeline) *providers.Run {
+	if pipeline == nil {
+		return nil
+	}
+	updatedAt := pipeline.UpdatedAt
+	if pipeline.FinishedAt != nil && !pipeline.FinishedAt.IsZero() {
+		updatedAt = *pipeline.FinishedAt
+	}
+	return &providers.Run{
+		ID:           pipeline.ID,
+		Name:         pipeline.Name,
+		DisplayTitle: pipeline.Name,
+		Status:       pipeline.Status,
+		Conclusion:   normalizeConclusion(pipeline.Status),
+		RunURL:       pipeline.WebURL,
+		HeadSHA:      pipeline.SHA,
+		CreatedAt:    pipeline.CreatedAt,
+		UpdatedAt:    updatedAt,
+		RunStartedAt: pipeline.StartedAt,
+	}
+}
+
+func toProviderRuns(pipelines []Pipeline) []providers.Run {
+	out := make([]providers.Run, 0, len(pipelines))
+	for _, pipeline := range pipelines {
+		if run := toProviderRun(&pipeline); run != nil {
+			out = append(out, *run)
+		}
+	}
+	return out
+}
+
+func toProviderJobs(jobs []Job) []providers.Job {
+	out := make([]providers.Job, 0, len(jobs))
+	for _, job := range jobs {
+		out = append(out, providers.Job{
+			ID:          job.ID,
+			Name:        job.Name,
+			Status:      job.Status,
+			Conclusion:  normalizeConclusion(job.Status),
+			HeadBranch:  job.Ref,
+			StartedAt:   job.StartedAt,
+			CompletedAt: job.FinishedAt,
+			RunURL:      job.WebURL,
+		})
+	}
+	return out
+}
+
+func parseCreatedRange(raw string) (string, string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return "", "", nil
+	}
+	parts := strings.Split(raw, "..")
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("created range must be start..end")
+	}
+	start, err := time.Parse(time.RFC3339, strings.TrimSpace(parts[0]))
+	if err != nil {
+		return "", "", fmt.Errorf("parse created range start: %w", err)
+	}
+	end, err := time.Parse(time.RFC3339, strings.TrimSpace(parts[1]))
+	if err != nil {
+		return "", "", fmt.Errorf("parse created range end: %w", err)
+	}
+	return start.UTC().Format(time.RFC3339), end.UTC().Format(time.RFC3339), nil
+}
+
+func normalizeConclusion(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "success":
+		return "success"
+	case "failed":
+		return "failure"
+	case "canceled":
+		return "cancelled"
+	case "skipped":
+		return "skipped"
+	default:
+		return ""
+	}
+}
+
+func translatePipelineStatus(status string) string {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "failure":
+		return "failed"
+	default:
+		return strings.TrimSpace(status)
+	}
+}
+
+func jobLogPriority(job Job) int {
+	switch strings.ToLower(strings.TrimSpace(job.Status)) {
+	case "failed", "canceled":
+		return 0
+	default:
+		return 1
+	}
+}
+
+func appendLimited(dst *bytes.Buffer, chunk []byte, limit int64) bool {
+	remaining := limit - int64(dst.Len())
+	if remaining <= 0 {
+		return false
+	}
+	if int64(len(chunk)) > remaining {
+		dst.Write(chunk[:remaining])
+		return false
+	}
+	dst.Write(chunk)
+	return true
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/gitlabapi/adapter_test.go
+++ b/internal/gitlabapi/adapter_test.go
@@ -1,0 +1,185 @@
+package gitlabapi
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/keithdoyle9/pipeline-mcp/internal/domain"
+	"github.com/keithdoyle9/pipeline-mcp/internal/providers"
+)
+
+type mockProviderClient struct {
+	getPipelineFn      func(context.Context, string, int64) (*Pipeline, error)
+	listPipelineJobsFn func(context.Context, string, int64) ([]Job, error)
+	downloadJobTraceFn func(context.Context, string, int64, int64) (string, error)
+	listProjectPipesFn func(context.Context, string, ListPipelinesOptions, int) ([]Pipeline, error)
+	retryPipelineFn    func(context.Context, string, int64) error
+}
+
+func (m *mockProviderClient) GetPipeline(ctx context.Context, projectPath string, pipelineID int64) (*Pipeline, error) {
+	return m.getPipelineFn(ctx, projectPath, pipelineID)
+}
+
+func (m *mockProviderClient) ListPipelineJobs(ctx context.Context, projectPath string, pipelineID int64) ([]Job, error) {
+	return m.listPipelineJobsFn(ctx, projectPath, pipelineID)
+}
+
+func (m *mockProviderClient) DownloadJobTrace(ctx context.Context, projectPath string, jobID int64, maxBytes int64) (string, error) {
+	return m.downloadJobTraceFn(ctx, projectPath, jobID, maxBytes)
+}
+
+func (m *mockProviderClient) ListProjectPipelines(ctx context.Context, projectPath string, opts ListPipelinesOptions, maxRuns int) ([]Pipeline, error) {
+	return m.listProjectPipesFn(ctx, projectPath, opts, maxRuns)
+}
+
+func (m *mockProviderClient) RetryPipeline(ctx context.Context, projectPath string, pipelineID int64) error {
+	return m.retryPipelineFn(ctx, projectPath, pipelineID)
+}
+
+func TestProviderAdapterParseRepository(t *testing.T) {
+	adapter := NewProviderAdapter(&mockProviderClient{}, "https://gitlab.example.com/api/v4")
+	repository, err := adapter.ParseRepository("group/subgroup/app")
+	if err != nil {
+		t.Fatalf("ParseRepository() error = %v", err)
+	}
+	if repository != "group/subgroup/app" {
+		t.Fatalf("unexpected repository %q", repository)
+	}
+}
+
+func TestProviderAdapterParseRunURL(t *testing.T) {
+	adapter := NewProviderAdapter(&mockProviderClient{}, "https://gitlab.example.com/gitlab/api/v4")
+	locator, err := adapter.ParseRunURL("https://gitlab.example.com/gitlab/group/subgroup/app/-/pipelines/77")
+	if err != nil {
+		t.Fatalf("ParseRunURL() error = %v", err)
+	}
+	if locator.Repository != "group/subgroup/app" || locator.RunID != 77 {
+		t.Fatalf("unexpected locator %+v", locator)
+	}
+}
+
+func TestProviderAdapterListRepositoryRunsTranslatesCreatedRangeAndStatus(t *testing.T) {
+	client := &mockProviderClient{
+		listProjectPipesFn: func(_ context.Context, projectPath string, opts ListPipelinesOptions, maxRuns int) ([]Pipeline, error) {
+			if projectPath != "group/subgroup/app" {
+				t.Fatalf("unexpected project path %q", projectPath)
+			}
+			if opts.CreatedAfter != "2026-03-06T11:00:00Z" || opts.CreatedBefore != "2026-03-06T12:00:00Z" {
+				t.Fatalf("unexpected created range %+v", opts)
+			}
+			if opts.Status != "failed" {
+				t.Fatalf("expected failed status, got %q", opts.Status)
+			}
+			if opts.OrderBy != "updated_at" || opts.Sort != "desc" {
+				t.Fatalf("unexpected ordering %+v", opts)
+			}
+			if maxRuns != 1 {
+				t.Fatalf("expected maxRuns 1, got %d", maxRuns)
+			}
+			return []Pipeline{{ID: 99, Name: "ci", Status: "failed"}}, nil
+		},
+	}
+	adapter := NewProviderAdapter(client, "https://gitlab.example.com/api/v4")
+
+	runs, err := adapter.ListRepositoryRuns(context.Background(), "group/subgroup/app", providers.ListRunsOptions{
+		Created: "2026-03-06T11:00:00Z..2026-03-06T12:00:00Z",
+		Status:  "failure",
+		PerPage: 1,
+	}, 1)
+	if err != nil {
+		t.Fatalf("ListRepositoryRuns() error = %v", err)
+	}
+	if len(runs) != 1 || runs[0].Conclusion != "failure" {
+		t.Fatalf("unexpected runs %+v", runs)
+	}
+}
+
+func TestProviderAdapterDownloadRunLogsOrdersFailedJobsFirstAndAppliesMaxBytes(t *testing.T) {
+	client := &mockProviderClient{
+		listPipelineJobsFn: func(_ context.Context, _ string, _ int64) ([]Job, error) {
+			now := time.Now().UTC()
+			return []Job{
+				{ID: 2, Name: "lint", Status: "success", StartedAt: &now},
+				{ID: 1, Name: "test", Status: "failed", StartedAt: &now},
+			}, nil
+		},
+		downloadJobTraceFn: func(_ context.Context, _ string, jobID int64, _ int64) (string, error) {
+			switch jobID {
+			case 1:
+				return "--- FAIL: TestCheckout", nil
+			case 2:
+				return "ok", nil
+			default:
+				return "", ErrLogsUnavailable
+			}
+		},
+	}
+	adapter := NewProviderAdapter(client, "https://gitlab.example.com/api/v4")
+
+	logs, err := adapter.DownloadRunLogs(context.Background(), "group/app", 10, 48)
+	if err != nil {
+		t.Fatalf("DownloadRunLogs() error = %v", err)
+	}
+	if !strings.Contains(logs, "test") {
+		t.Fatalf("expected failed job trace in logs, got %q", logs)
+	}
+	if strings.Contains(logs, "lint") {
+		t.Fatalf("expected maxBytes truncation before lint job, got %q", logs)
+	}
+}
+
+func TestProviderAdapterDownloadRunLogsReturnsUnavailableWhenNoTraceExists(t *testing.T) {
+	client := &mockProviderClient{
+		listPipelineJobsFn: func(_ context.Context, _ string, _ int64) ([]Job, error) {
+			return []Job{{ID: 1, Name: "test", Status: "failed"}}, nil
+		},
+		downloadJobTraceFn: func(_ context.Context, _ string, _ int64, _ int64) (string, error) {
+			return "", ErrLogsUnavailable
+		},
+	}
+	adapter := NewProviderAdapter(client, "https://gitlab.example.com/api/v4")
+
+	_, err := adapter.DownloadRunLogs(context.Background(), "group/app", 10, 1024)
+	if !errors.Is(err, ErrLogsUnavailable) {
+		t.Fatalf("expected ErrLogsUnavailable, got %v", err)
+	}
+}
+
+func TestProviderAdapterMapError(t *testing.T) {
+	adapter := NewProviderAdapter(&mockProviderClient{}, "https://gitlab.example.com/api/v4")
+	testCases := []struct {
+		err      error
+		wantCode string
+	}{
+		{err: ErrUnauthorized, wantCode: domain.ErrorCodeUnauthorized},
+		{err: ErrNotFound, wantCode: domain.ErrorCodeUnauthorized},
+		{err: ErrLogsUnavailable, wantCode: domain.ErrorCodeLogUnavailable},
+		{err: ErrRateLimited, wantCode: domain.ErrorCodeRateLimited},
+		{err: ErrProviderUnavailable, wantCode: domain.ErrorCodeProviderUnavailable},
+		{err: ErrFullRerunUnsupported, wantCode: domain.ErrorCodeInvalidInput},
+	}
+	for _, tc := range testCases {
+		toolErr := adapter.MapError(tc.err)
+		if toolErr == nil || toolErr.Code != tc.wantCode {
+			t.Fatalf("MapError(%v) = %+v, want code %s", tc.err, toolErr, tc.wantCode)
+		}
+	}
+}
+
+func TestProviderAdapterRerunRejectsFullRun(t *testing.T) {
+	client := &mockProviderClient{
+		retryPipelineFn: func(context.Context, string, int64) error {
+			t.Fatal("expected rerun rejection before API call")
+			return nil
+		},
+	}
+	adapter := NewProviderAdapter(client, "https://gitlab.example.com/api/v4")
+
+	err := adapter.Rerun(context.Background(), "group/app", 12, false)
+	if !errors.Is(err, ErrFullRerunUnsupported) {
+		t.Fatalf("expected ErrFullRerunUnsupported, got %v", err)
+	}
+}

--- a/internal/gitlabapi/client.go
+++ b/internal/gitlabapi/client.go
@@ -1,0 +1,276 @@
+package gitlabapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	defaultPerPage = 100
+	maxAttempts    = 3
+)
+
+type Client struct {
+	baseURL    string
+	readToken  string
+	writeToken string
+	userAgent  string
+	httpClient *http.Client
+}
+
+func NewClient(baseURL, readToken, writeToken, userAgent string, timeout time.Duration) *Client {
+	if timeout <= 0 {
+		timeout = 25 * time.Second
+	}
+	return &Client{
+		baseURL:    strings.TrimRight(baseURL, "/"),
+		readToken:  strings.TrimSpace(readToken),
+		writeToken: strings.TrimSpace(writeToken),
+		userAgent:  userAgent,
+		httpClient: &http.Client{Timeout: timeout},
+	}
+}
+
+func (c *Client) GetPipeline(ctx context.Context, projectPath string, pipelineID int64) (*Pipeline, error) {
+	endpoint := fmt.Sprintf("/projects/%s/pipelines/%d", url.PathEscape(projectPath), pipelineID)
+	var pipeline Pipeline
+	if _, err := c.doJSON(ctx, http.MethodGet, endpoint, nil, false, &pipeline); err != nil {
+		return nil, err
+	}
+	return &pipeline, nil
+}
+
+func (c *Client) ListPipelineJobs(ctx context.Context, projectPath string, pipelineID int64) ([]Job, error) {
+	jobs := make([]Job, 0, 32)
+	for page := 1; page <= 10; page++ {
+		endpoint := fmt.Sprintf("/projects/%s/pipelines/%d/jobs?per_page=%d&page=%d", url.PathEscape(projectPath), pipelineID, defaultPerPage, page)
+		var pageJobs []Job
+		if _, err := c.doJSON(ctx, http.MethodGet, endpoint, nil, false, &pageJobs); err != nil {
+			return nil, err
+		}
+		if len(pageJobs) == 0 {
+			break
+		}
+		jobs = append(jobs, pageJobs...)
+		if len(pageJobs) < defaultPerPage {
+			break
+		}
+	}
+	return jobs, nil
+}
+
+func (c *Client) DownloadJobTrace(ctx context.Context, projectPath string, jobID int64, maxBytes int64) (string, error) {
+	endpoint := fmt.Sprintf("/projects/%s/jobs/%d/trace", url.PathEscape(projectPath), jobID)
+	body, _, err := c.doBytes(ctx, http.MethodGet, endpoint, nil, false)
+	if err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return "", ErrLogsUnavailable
+		}
+		return "", err
+	}
+	if len(body) == 0 {
+		return "", ErrLogsUnavailable
+	}
+	if maxBytes <= 0 || int64(len(body)) <= maxBytes {
+		return string(body), nil
+	}
+	return string(body[:maxBytes]), nil
+}
+
+func (c *Client) ListProjectPipelines(ctx context.Context, projectPath string, opts ListPipelinesOptions, maxRuns int) ([]Pipeline, error) {
+	if maxRuns <= 0 {
+		maxRuns = defaultPerPage
+	}
+	if opts.PerPage <= 0 || opts.PerPage > defaultPerPage {
+		opts.PerPage = defaultPerPage
+	}
+
+	pipelines := make([]Pipeline, 0, maxRuns)
+	for page := 1; len(pipelines) < maxRuns && page <= 10; page++ {
+		query := url.Values{}
+		query.Set("per_page", strconv.Itoa(opts.PerPage))
+		query.Set("page", strconv.Itoa(page))
+		if opts.CreatedAfter != "" {
+			query.Set("created_after", opts.CreatedAfter)
+		}
+		if opts.CreatedBefore != "" {
+			query.Set("created_before", opts.CreatedBefore)
+		}
+		if opts.Status != "" {
+			query.Set("status", opts.Status)
+		}
+		if opts.OrderBy != "" {
+			query.Set("order_by", opts.OrderBy)
+		}
+		if opts.Sort != "" {
+			query.Set("sort", opts.Sort)
+		}
+
+		endpoint := fmt.Sprintf("/projects/%s/pipelines?%s", url.PathEscape(projectPath), query.Encode())
+		var pagePipelines []Pipeline
+		if _, err := c.doJSON(ctx, http.MethodGet, endpoint, nil, false, &pagePipelines); err != nil {
+			return nil, err
+		}
+		if len(pagePipelines) == 0 {
+			break
+		}
+		pipelines = append(pipelines, pagePipelines...)
+		if len(pagePipelines) < opts.PerPage {
+			break
+		}
+	}
+	if len(pipelines) > maxRuns {
+		pipelines = pipelines[:maxRuns]
+	}
+	return pipelines, nil
+}
+
+func (c *Client) RetryPipeline(ctx context.Context, projectPath string, pipelineID int64) error {
+	if strings.TrimSpace(c.writeToken) == "" {
+		return ErrWriteTokenRequired
+	}
+	endpoint := fmt.Sprintf("/projects/%s/pipelines/%d/retry", url.PathEscape(projectPath), pipelineID)
+	_, err := c.doJSON(ctx, http.MethodPost, endpoint, nil, true, nil)
+	return err
+}
+
+func (c *Client) doJSON(ctx context.Context, method, endpoint string, payload any, write bool, out any) (http.Header, error) {
+	var body []byte
+	var err error
+	if payload != nil {
+		body, err = json.Marshal(payload)
+		if err != nil {
+			return nil, fmt.Errorf("marshal request body: %w", err)
+		}
+	}
+
+	respBody, headers, err := c.doBytes(ctx, method, endpoint, body, write)
+	if err != nil {
+		return headers, err
+	}
+	if out == nil || len(respBody) == 0 {
+		return headers, nil
+	}
+	if err := json.Unmarshal(respBody, out); err != nil {
+		return headers, fmt.Errorf("decode response: %w", err)
+	}
+	return headers, nil
+}
+
+func (c *Client) doBytes(ctx context.Context, method, endpoint string, body []byte, write bool) ([]byte, http.Header, error) {
+	var lastErr error
+	for attempt := 1; attempt <= maxAttempts; attempt++ {
+		responseBody, headers, retry, err := c.doOnce(ctx, method, endpoint, body, write)
+		if err == nil {
+			return responseBody, headers, nil
+		}
+		lastErr = err
+		if !retry || attempt == maxAttempts {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return nil, nil, ctx.Err()
+		case <-time.After(time.Duration(attempt*attempt) * 200 * time.Millisecond):
+		}
+	}
+	return nil, nil, lastErr
+}
+
+func (c *Client) doOnce(ctx context.Context, method, endpoint string, body []byte, write bool) ([]byte, http.Header, bool, error) {
+	fullURL := c.baseURL + endpoint
+	var reader io.Reader
+	if len(body) > 0 {
+		reader = bytes.NewReader(body)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, fullURL, reader)
+	if err != nil {
+		return nil, nil, false, fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if c.userAgent != "" {
+		req.Header.Set("User-Agent", c.userAgent)
+	}
+	if len(body) > 0 {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token := c.readToken; token != "" {
+		req.Header.Set("PRIVATE-TOKEN", token)
+	}
+	if write && c.writeToken != "" {
+		req.Header.Set("PRIVATE-TOKEN", c.writeToken)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, nil, true, fmt.Errorf("gitlab request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	responseBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, resp.Header, false, fmt.Errorf("read response body: %w", err)
+	}
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		return responseBody, resp.Header, false, nil
+	}
+
+	apiErr := &APIError{
+		Status:     resp.StatusCode,
+		Message:    parseAPIErrorMessage(responseBody),
+		RetryAfter: resp.Header.Get("Retry-After"),
+	}
+
+	switch resp.StatusCode {
+	case http.StatusUnauthorized, http.StatusForbidden:
+		return nil, resp.Header, false, fmt.Errorf("%w: %v", ErrUnauthorized, apiErr)
+	case http.StatusNotFound:
+		return nil, resp.Header, false, fmt.Errorf("%w: %v", ErrNotFound, apiErr)
+	case http.StatusTooManyRequests:
+		return nil, resp.Header, true, fmt.Errorf("%w: %v", ErrRateLimited, apiErr)
+	default:
+		if resp.StatusCode >= 500 {
+			return nil, resp.Header, true, fmt.Errorf("%w: %v", ErrProviderUnavailable, apiErr)
+		}
+	}
+
+	return nil, resp.Header, false, fmt.Errorf("gitlab api error: %v", apiErr)
+}
+
+func parseAPIErrorMessage(body []byte) string {
+	if len(body) == 0 {
+		return ""
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(body, &payload); err != nil {
+		return strings.TrimSpace(string(body))
+	}
+	for _, key := range []string{"message", "error"} {
+		value, ok := payload[key]
+		if !ok {
+			continue
+		}
+		switch typed := value.(type) {
+		case string:
+			return strings.TrimSpace(typed)
+		default:
+			encoded, err := json.Marshal(typed)
+			if err == nil {
+				return string(encoded)
+			}
+		}
+	}
+	return strings.TrimSpace(string(body))
+}

--- a/internal/gitlabapi/client_test.go
+++ b/internal/gitlabapi/client_test.go
@@ -1,0 +1,152 @@
+package gitlabapi
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestClientGetPipelineAndJobs(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.EscapedPath() {
+		case "/api/v4/projects/group%2Fapp/pipelines/10":
+			_ = json.NewEncoder(w).Encode(Pipeline{ID: 10, Name: "ci", WebURL: "https://gitlab.example.com/group/app/-/pipelines/10"})
+		case "/api/v4/projects/group%2Fapp/pipelines/10/jobs":
+			_ = json.NewEncoder(w).Encode([]Job{{ID: 1, Name: "test", Status: "failed"}})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL+"/api/v4", "read-token", "", "test-agent", 5*time.Second)
+	pipeline, err := client.GetPipeline(context.Background(), "group/app", 10)
+	if err != nil {
+		t.Fatalf("GetPipeline() error = %v", err)
+	}
+	if pipeline.ID != 10 {
+		t.Fatalf("expected pipeline id 10, got %d", pipeline.ID)
+	}
+
+	jobs, err := client.ListPipelineJobs(context.Background(), "group/app", 10)
+	if err != nil {
+		t.Fatalf("ListPipelineJobs() error = %v", err)
+	}
+	if len(jobs) != 1 {
+		t.Fatalf("expected 1 job, got %d", len(jobs))
+	}
+}
+
+func TestClientListProjectPipelinesTranslatesCreatedRange(t *testing.T) {
+	var gotQuery string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery = r.URL.RawQuery
+		_ = json.NewEncoder(w).Encode([]Pipeline{{ID: 10}})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "read-token", "", "test-agent", 5*time.Second)
+	_, err := client.ListProjectPipelines(context.Background(), "group/app", ListPipelinesOptions{
+		PerPage:       1,
+		CreatedAfter:  "2026-03-06T11:00:00Z",
+		CreatedBefore: "2026-03-06T12:00:00Z",
+		Status:        "failed",
+		OrderBy:       "updated_at",
+		Sort:          "desc",
+	}, 1)
+	if err != nil {
+		t.Fatalf("ListProjectPipelines() error = %v", err)
+	}
+	for _, expected := range []string{"created_after=2026-03-06T11%3A00%3A00Z", "created_before=2026-03-06T12%3A00%3A00Z", "status=failed", "order_by=updated_at", "sort=desc"} {
+		if !strings.Contains(gotQuery, expected) {
+			t.Fatalf("expected query parameter %q, got %q", expected, gotQuery)
+		}
+	}
+}
+
+func TestClientDownloadJobTraceMapsNotFoundToLogsUnavailable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.NotFound(w, nil)
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "read-token", "", "test-agent", 5*time.Second)
+	_, err := client.DownloadJobTrace(context.Background(), "group/app", 44, 1024)
+	if !errors.Is(err, ErrLogsUnavailable) {
+		t.Fatalf("expected ErrLogsUnavailable, got %v", err)
+	}
+}
+
+func TestClientRetryPipelineRequiresWriteToken(t *testing.T) {
+	client := NewClient("https://gitlab.com/api/v4", "read", "", "test-agent", 5*time.Second)
+	err := client.RetryPipeline(context.Background(), "group/app", 12)
+	if err != ErrWriteTokenRequired {
+		t.Fatalf("expected ErrWriteTokenRequired, got %v", err)
+	}
+}
+
+func TestClientRetriesTransientProviderFailures(t *testing.T) {
+	var attempts atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if attempts.Add(1) < 3 {
+			http.Error(w, `{"message":"temporary upstream failure"}`, http.StatusBadGateway)
+			return
+		}
+		_ = json.NewEncoder(w).Encode(Pipeline{ID: 42, Name: "ci"})
+	}))
+	defer server.Close()
+
+	client := NewClient(server.URL, "read-token", "", "test-agent", 5*time.Second)
+	pipeline, err := client.GetPipeline(context.Background(), "group/app", 42)
+	if err != nil {
+		t.Fatalf("GetPipeline() error = %v", err)
+	}
+	if pipeline == nil || pipeline.ID != 42 {
+		t.Fatalf("expected successful retry result, got %#v", pipeline)
+	}
+	if got := attempts.Load(); got != 3 {
+		t.Fatalf("expected 3 attempts, got %d", got)
+	}
+}
+
+func TestClientRetriesTransientTransportFailures(t *testing.T) {
+	var attempts atomic.Int32
+	client := NewClient("https://gitlab.com/api/v4", "read-token", "", "test-agent", 5*time.Second)
+	client.httpClient = &http.Client{
+		Timeout: 5 * time.Second,
+		Transport: roundTripFunc(func(_ *http.Request) (*http.Response, error) {
+			if attempts.Add(1) == 1 {
+				return nil, errors.New("temporary dial failure")
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     make(http.Header),
+				Body:       io.NopCloser(strings.NewReader(`{"id":55,"name":"ci"}`)),
+			}, nil
+		}),
+	}
+
+	pipeline, err := client.GetPipeline(context.Background(), "group/app", 55)
+	if err != nil {
+		t.Fatalf("GetPipeline() error = %v", err)
+	}
+	if pipeline == nil || pipeline.ID != 55 {
+		t.Fatalf("expected successful retry result, got %#v", pipeline)
+	}
+	if got := attempts.Load(); got != 2 {
+		t.Fatalf("expected 2 attempts, got %d", got)
+	}
+}
+
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}

--- a/internal/gitlabapi/errors.go
+++ b/internal/gitlabapi/errors.go
@@ -1,0 +1,35 @@
+package gitlabapi
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+)
+
+var (
+	ErrUnauthorized         = errors.New("gitlab unauthorized")
+	ErrRateLimited          = errors.New("gitlab rate limited")
+	ErrLogsUnavailable      = errors.New("gitlab logs unavailable")
+	ErrProviderUnavailable  = errors.New("provider unavailable")
+	ErrNotFound             = errors.New("resource not found")
+	ErrWriteTokenRequired   = errors.New("write token required")
+	ErrFullRerunUnsupported = errors.New("gitlab full pipeline rerun is unsupported")
+	ErrCheckRunUnsupported  = errors.New("gitlab check run metadata is unsupported")
+)
+
+type APIError struct {
+	Status     int
+	Message    string
+	RetryAfter string
+}
+
+func (e *APIError) Error() string {
+	status := http.StatusText(e.Status)
+	if status == "" {
+		status = "unknown"
+	}
+	if e.Message == "" {
+		return fmt.Sprintf("gitlab api error: %d %s", e.Status, status)
+	}
+	return fmt.Sprintf("gitlab api error: %d %s: %s", e.Status, status, e.Message)
+}

--- a/internal/gitlabapi/locator.go
+++ b/internal/gitlabapi/locator.go
@@ -1,0 +1,119 @@
+package gitlabapi
+
+import (
+	"fmt"
+	"net/url"
+	"path"
+	"strconv"
+	"strings"
+)
+
+type RunLocator struct {
+	ProjectPath string
+	RunID       int64
+	RunURL      string
+}
+
+func (r RunLocator) Repository() string {
+	return r.ProjectPath
+}
+
+func ParseProjectPath(project string) (string, error) {
+	project = strings.Trim(strings.TrimSpace(project), "/")
+	if project == "" {
+		return "", fmt.Errorf("repository is required")
+	}
+	parts := strings.Split(project, "/")
+	if len(parts) < 2 {
+		return "", fmt.Errorf("repository must be in group/project format")
+	}
+	for _, part := range parts {
+		if strings.TrimSpace(part) == "" {
+			return "", fmt.Errorf("repository contains an empty path segment")
+		}
+	}
+	return strings.Join(parts, "/"), nil
+}
+
+func ParseRunURL(raw string) (*RunLocator, error) {
+	return ParseRunURLForBase(raw, "https://gitlab.com/api/v4")
+}
+
+func ParseRunURLForBase(raw, baseURL string) (*RunLocator, error) {
+	if strings.TrimSpace(raw) == "" {
+		return nil, fmt.Errorf("run_url is required")
+	}
+
+	runURL, err := url.Parse(strings.TrimSpace(raw))
+	if err != nil {
+		return nil, fmt.Errorf("parse run url: %w", err)
+	}
+
+	webBase, err := webBaseURL(baseURL)
+	if err != nil {
+		return nil, err
+	}
+	if !strings.EqualFold(runURL.Host, webBase.Host) {
+		return nil, fmt.Errorf("unsupported host %q", runURL.Host)
+	}
+
+	cleanPath := strings.Trim(path.Clean(runURL.Path), "/")
+	basePath := strings.Trim(path.Clean(webBase.Path), "/")
+	relativePath := cleanPath
+	if basePath != "" && basePath != "." {
+		prefix := basePath + "/"
+		if !strings.HasPrefix(cleanPath, prefix) {
+			return nil, fmt.Errorf("unsupported run url path")
+		}
+		relativePath = strings.TrimPrefix(cleanPath, prefix)
+	}
+
+	segments := strings.Split(relativePath, "/")
+	if len(segments) < 4 || segments[len(segments)-2] != "pipelines" || segments[len(segments)-3] != "-" {
+		return nil, fmt.Errorf("unsupported run url path")
+	}
+
+	runID, err := strconv.ParseInt(segments[len(segments)-1], 10, 64)
+	if err != nil {
+		return nil, fmt.Errorf("parse run id: %w", err)
+	}
+	projectPath, err := ParseProjectPath(strings.Join(segments[:len(segments)-3], "/"))
+	if err != nil {
+		return nil, err
+	}
+
+	return &RunLocator{
+		ProjectPath: projectPath,
+		RunID:       runID,
+		RunURL:      strings.TrimRight(webBase.String(), "/") + "/" + projectPath + "/-/pipelines/" + strconv.FormatInt(runID, 10),
+	}, nil
+}
+
+func RunURLForBase(projectPath string, runID int64, baseURL string) string {
+	webBase, err := webBaseURL(baseURL)
+	if err != nil {
+		return ""
+	}
+	projectPath, err = ParseProjectPath(projectPath)
+	if err != nil {
+		return ""
+	}
+	return strings.TrimRight(webBase.String(), "/") + "/" + projectPath + "/-/pipelines/" + strconv.FormatInt(runID, 10)
+}
+
+func webBaseURL(baseURL string) (*url.URL, error) {
+	base, err := url.Parse(strings.TrimSpace(baseURL))
+	if err != nil {
+		return nil, fmt.Errorf("parse gitlab api base url: %w", err)
+	}
+	if strings.TrimSpace(base.Host) == "" {
+		return nil, fmt.Errorf("gitlab api base url host is required")
+	}
+
+	webBase := *base
+	webBase.RawQuery = ""
+	webBase.Fragment = ""
+	webBase.Path = strings.TrimSuffix(webBase.Path, "/api/v4")
+	webBase.Path = strings.TrimRight(webBase.Path, "/")
+	return &webBase, nil
+}

--- a/internal/gitlabapi/locator_test.go
+++ b/internal/gitlabapi/locator_test.go
@@ -1,0 +1,39 @@
+package gitlabapi
+
+import "testing"
+
+func TestParseRunURLForBase(t *testing.T) {
+	locator, err := ParseRunURLForBase("https://gitlab.example.com/root/team/app/-/pipelines/123?foo=bar", "https://gitlab.example.com/api/v4")
+	if err != nil {
+		t.Fatalf("ParseRunURLForBase() error = %v", err)
+	}
+	if locator.ProjectPath != "root/team/app" || locator.RunID != 123 {
+		t.Fatalf("unexpected locator: %+v", locator)
+	}
+}
+
+func TestParseRunURLForBaseSupportsSubpathInstance(t *testing.T) {
+	locator, err := ParseRunURLForBase("https://gitlab.example.com/gitlab/root/team/app/-/pipelines/456", "https://gitlab.example.com/gitlab/api/v4")
+	if err != nil {
+		t.Fatalf("ParseRunURLForBase() error = %v", err)
+	}
+	if locator.ProjectPath != "root/team/app" || locator.RunID != 456 {
+		t.Fatalf("unexpected locator: %+v", locator)
+	}
+}
+
+func TestParseProjectPath(t *testing.T) {
+	project, err := ParseProjectPath("group/subgroup/app")
+	if err != nil {
+		t.Fatalf("ParseProjectPath() error = %v", err)
+	}
+	if project != "group/subgroup/app" {
+		t.Fatalf("unexpected project path %q", project)
+	}
+}
+
+func TestParseProjectPathRejectsInvalid(t *testing.T) {
+	if _, err := ParseProjectPath("app"); err == nil {
+		t.Fatal("expected invalid project path error")
+	}
+}

--- a/internal/gitlabapi/types.go
+++ b/internal/gitlabapi/types.go
@@ -1,0 +1,38 @@
+package gitlabapi
+
+import "time"
+
+type Pipeline struct {
+	ID             int64      `json:"id"`
+	Name           string     `json:"name"`
+	Status         string     `json:"status"`
+	WebURL         string     `json:"web_url"`
+	SHA            string     `json:"sha"`
+	CreatedAt      time.Time  `json:"created_at"`
+	UpdatedAt      time.Time  `json:"updated_at"`
+	StartedAt      *time.Time `json:"started_at"`
+	FinishedAt     *time.Time `json:"finished_at"`
+	Duration       *float64   `json:"duration"`
+	QueuedDuration *float64   `json:"queued_duration"`
+}
+
+type Job struct {
+	ID         int64      `json:"id"`
+	Status     string     `json:"status"`
+	Stage      string     `json:"stage"`
+	Name       string     `json:"name"`
+	Ref        string     `json:"ref"`
+	WebURL     string     `json:"web_url"`
+	StartedAt  *time.Time `json:"started_at"`
+	FinishedAt *time.Time `json:"finished_at"`
+}
+
+type ListPipelinesOptions struct {
+	PerPage       int
+	Page          int
+	CreatedAfter  string
+	CreatedBefore string
+	Status        string
+	OrderBy       string
+	Sort          string
+}

--- a/internal/service/service.go
+++ b/internal/service/service.go
@@ -266,7 +266,7 @@ func (s *Service) Rerun(ctx context.Context, providerID, repository string, runI
 		return nil, domain.NewToolError(
 			domain.ErrorCodeUnauthorized,
 			"Mutation tools are disabled by configuration.",
-			"Set DISABLE_MUTATIONS=false and provide GITHUB_WRITE_TOKEN with actions:write.",
+			"Set DISABLE_MUTATIONS=false and provide the provider-specific write token for the selected provider.",
 			false,
 			nil,
 		)

--- a/internal/service/service_test.go
+++ b/internal/service/service_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/keithdoyle9/pipeline-mcp/config"
 	"github.com/keithdoyle9/pipeline-mcp/internal/domain"
 	"github.com/keithdoyle9/pipeline-mcp/internal/githubapi"
+	"github.com/keithdoyle9/pipeline-mcp/internal/gitlabapi"
 	"github.com/keithdoyle9/pipeline-mcp/internal/providers"
 	"github.com/keithdoyle9/pipeline-mcp/internal/telemetry"
 )
@@ -75,6 +76,49 @@ func (m *mockGitHubClient) Rerun(ctx context.Context, owner, repo string, runID 
 		return nil
 	}
 	return m.rerunFn(ctx, owner, repo, runID, failedJobsOnly)
+}
+
+type mockGitLabClient struct {
+	getPipelineFn      func(ctx context.Context, projectPath string, pipelineID int64) (*gitlabapi.Pipeline, error)
+	listPipelineJobsFn func(ctx context.Context, projectPath string, pipelineID int64) ([]gitlabapi.Job, error)
+	downloadJobTraceFn func(ctx context.Context, projectPath string, jobID int64, maxBytes int64) (string, error)
+	listPipelinesFn    func(ctx context.Context, projectPath string, opts gitlabapi.ListPipelinesOptions, maxRuns int) ([]gitlabapi.Pipeline, error)
+	retryPipelineFn    func(ctx context.Context, projectPath string, pipelineID int64) error
+}
+
+func (m *mockGitLabClient) GetPipeline(ctx context.Context, projectPath string, pipelineID int64) (*gitlabapi.Pipeline, error) {
+	if m.getPipelineFn == nil {
+		return nil, nil
+	}
+	return m.getPipelineFn(ctx, projectPath, pipelineID)
+}
+
+func (m *mockGitLabClient) ListPipelineJobs(ctx context.Context, projectPath string, pipelineID int64) ([]gitlabapi.Job, error) {
+	if m.listPipelineJobsFn == nil {
+		return nil, nil
+	}
+	return m.listPipelineJobsFn(ctx, projectPath, pipelineID)
+}
+
+func (m *mockGitLabClient) DownloadJobTrace(ctx context.Context, projectPath string, jobID int64, maxBytes int64) (string, error) {
+	if m.downloadJobTraceFn == nil {
+		return "", nil
+	}
+	return m.downloadJobTraceFn(ctx, projectPath, jobID, maxBytes)
+}
+
+func (m *mockGitLabClient) ListProjectPipelines(ctx context.Context, projectPath string, opts gitlabapi.ListPipelinesOptions, maxRuns int) ([]gitlabapi.Pipeline, error) {
+	if m.listPipelinesFn == nil {
+		return nil, nil
+	}
+	return m.listPipelinesFn(ctx, projectPath, opts, maxRuns)
+}
+
+func (m *mockGitLabClient) RetryPipeline(ctx context.Context, projectPath string, pipelineID int64) error {
+	if m.retryPipelineFn == nil {
+		return nil
+	}
+	return m.retryPipelineFn(ctx, projectPath, pipelineID)
 }
 
 type memoryAuditStore struct {
@@ -519,6 +563,69 @@ func TestRerunRequiresReasonAndAudit(t *testing.T) {
 	}
 }
 
+func TestGitLabRerunRejectsFullRunBeforeAPIInvocation(t *testing.T) {
+	auditStore := &memoryAuditStore{}
+	cfg := testConfig(false)
+	gitLabClient := &mockGitLabClient{
+		retryPipelineFn: func(context.Context, string, int64) error {
+			t.Fatal("expected GitLab full rerun rejection before API call")
+			return nil
+		},
+	}
+
+	svc := &Service{
+		cfg: cfg,
+		providers: mustTestRegistry(
+			t,
+			githubapi.NewProviderAdapter(&mockGitHubClient{}, cfg.GitHubAPIBaseURL),
+			gitlabapi.NewProviderAdapter(gitLabClient, cfg.GitLabAPIBaseURL),
+		),
+		audit:     auditStore,
+		telemetry: telemetry.NewCollector(""),
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:       time.Now,
+	}
+
+	_, toolErr := svc.Rerun(context.Background(), "gitlab_ci", "group/subgroup/app", 44, false, "retry all jobs")
+	if toolErr == nil {
+		t.Fatal("expected tool error")
+	}
+	if toolErr.Code != domain.ErrorCodeInvalidInput {
+		t.Fatalf("expected %s, got %s", domain.ErrorCodeInvalidInput, toolErr.Code)
+	}
+	if len(auditStore.events) != 1 || auditStore.events[0].Outcome != "failed" {
+		t.Fatalf("expected failed audit event, got %+v", auditStore.events)
+	}
+}
+
+func TestGitLabRerunMapsMissingWriteTokenToUnauthorized(t *testing.T) {
+	cfg := testConfig(false)
+	svc := &Service{
+		cfg: cfg,
+		providers: mustTestRegistry(
+			t,
+			githubapi.NewProviderAdapter(&mockGitHubClient{}, cfg.GitHubAPIBaseURL),
+			gitlabapi.NewProviderAdapter(&mockGitLabClient{
+				retryPipelineFn: func(context.Context, string, int64) error {
+					return gitlabapi.ErrWriteTokenRequired
+				},
+			}, cfg.GitLabAPIBaseURL),
+		),
+		audit:     &memoryAuditStore{},
+		telemetry: telemetry.NewCollector(""),
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:       time.Now,
+	}
+
+	_, toolErr := svc.Rerun(context.Background(), "gitlab_ci", "group/subgroup/app", 45, true, "retry failed jobs")
+	if toolErr == nil {
+		t.Fatal("expected tool error")
+	}
+	if toolErr.Code != domain.ErrorCodeUnauthorized {
+		t.Fatalf("expected %s, got %s", domain.ErrorCodeUnauthorized, toolErr.Code)
+	}
+}
+
 func TestComparePerformance(t *testing.T) {
 	now := time.Date(2026, 3, 6, 12, 0, 0, 0, time.UTC)
 	mock := &mockGitHubClient{
@@ -873,6 +980,7 @@ func testConfig(disableMutations bool) *config.Config {
 		ServerName:          "pipeline-mcp",
 		Version:             "test",
 		GitHubAPIBaseURL:    "https://api.github.com",
+		GitLabAPIBaseURL:    "https://gitlab.com/api/v4",
 		DisableMutations:    disableMutations,
 		MaxLogBytes:         20 * 1024 * 1024,
 		DefaultLookbackDays: 14,

--- a/tools/acceptance_test.go
+++ b/tools/acceptance_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/keithdoyle9/pipeline-mcp/config"
 	"github.com/keithdoyle9/pipeline-mcp/internal/domain"
 	"github.com/keithdoyle9/pipeline-mcp/internal/githubapi"
+	"github.com/keithdoyle9/pipeline-mcp/internal/gitlabapi"
 	"github.com/keithdoyle9/pipeline-mcp/internal/providers"
 	"github.com/keithdoyle9/pipeline-mcp/internal/service"
 	"github.com/keithdoyle9/pipeline-mcp/internal/telemetry"
@@ -80,6 +81,49 @@ func (m *acceptanceGitHubClient) Rerun(ctx context.Context, owner, repo string, 
 		return nil
 	}
 	return m.rerunFn(ctx, owner, repo, runID, failedJobsOnly)
+}
+
+type acceptanceGitLabClient struct {
+	getPipelineFn      func(ctx context.Context, projectPath string, pipelineID int64) (*gitlabapi.Pipeline, error)
+	listPipelineJobsFn func(ctx context.Context, projectPath string, pipelineID int64) ([]gitlabapi.Job, error)
+	downloadJobTraceFn func(ctx context.Context, projectPath string, jobID int64, maxBytes int64) (string, error)
+	listPipelinesFn    func(ctx context.Context, projectPath string, opts gitlabapi.ListPipelinesOptions, maxRuns int) ([]gitlabapi.Pipeline, error)
+	retryPipelineFn    func(ctx context.Context, projectPath string, pipelineID int64) error
+}
+
+func (m *acceptanceGitLabClient) GetPipeline(ctx context.Context, projectPath string, pipelineID int64) (*gitlabapi.Pipeline, error) {
+	if m.getPipelineFn == nil {
+		return nil, nil
+	}
+	return m.getPipelineFn(ctx, projectPath, pipelineID)
+}
+
+func (m *acceptanceGitLabClient) ListPipelineJobs(ctx context.Context, projectPath string, pipelineID int64) ([]gitlabapi.Job, error) {
+	if m.listPipelineJobsFn == nil {
+		return nil, nil
+	}
+	return m.listPipelineJobsFn(ctx, projectPath, pipelineID)
+}
+
+func (m *acceptanceGitLabClient) DownloadJobTrace(ctx context.Context, projectPath string, jobID int64, maxBytes int64) (string, error) {
+	if m.downloadJobTraceFn == nil {
+		return "", nil
+	}
+	return m.downloadJobTraceFn(ctx, projectPath, jobID, maxBytes)
+}
+
+func (m *acceptanceGitLabClient) ListProjectPipelines(ctx context.Context, projectPath string, opts gitlabapi.ListPipelinesOptions, maxRuns int) ([]gitlabapi.Pipeline, error) {
+	if m.listPipelinesFn == nil {
+		return nil, nil
+	}
+	return m.listPipelinesFn(ctx, projectPath, opts, maxRuns)
+}
+
+func (m *acceptanceGitLabClient) RetryPipeline(ctx context.Context, projectPath string, pipelineID int64) error {
+	if m.retryPipelineFn == nil {
+		return nil
+	}
+	return m.retryPipelineFn(ctx, projectPath, pipelineID)
 }
 
 type acceptanceAuditStore struct {
@@ -293,7 +337,229 @@ func TestAcceptanceAC5ComparePerformanceReturnsBaselineCurrentAndFailureBreakdow
 	}
 }
 
+func TestAcceptanceGitLabAC1DiagnoseFailureReturnsDiagnosticAndRecommendations(t *testing.T) {
+	deps := newAcceptanceDependenciesWithAdapters(
+		t,
+		[]providers.Adapter{
+			githubapi.NewProviderAdapter(&acceptanceGitHubClient{}, "https://api.github.com"),
+			gitlabapi.NewProviderAdapter(&acceptanceGitLabClient{
+				getPipelineFn: func(context.Context, string, int64) (*gitlabapi.Pipeline, error) {
+					return &gitlabapi.Pipeline{ID: 55, Name: "ci", WebURL: "https://gitlab.example.com/group/app/-/pipelines/55"}, nil
+				},
+				listPipelineJobsFn: func(context.Context, string, int64) ([]gitlabapi.Job, error) {
+					return []gitlabapi.Job{{ID: 4, Name: "test", Status: "failed"}}, nil
+				},
+				downloadJobTraceFn: func(context.Context, string, int64, int64) (string, error) {
+					return "--- FAIL: TestCheckout\nAssertionError: expected 200 got 500", nil
+				},
+			}, "https://gitlab.example.com/api/v4"),
+		},
+		&acceptanceAuditStore{},
+		true,
+	)
+
+	_, out, err := deps.diagnoseFailure(context.Background(), nil, DiagnoseFailureInput{
+		Provider:   "gitlab_ci",
+		Repository: "group/app",
+		RunID:      55,
+	})
+	if err != nil {
+		t.Fatalf("diagnoseFailure() error = %v", err)
+	}
+	if out.Error != nil {
+		t.Fatalf("unexpected tool error: %+v", out.Error)
+	}
+	if out.Diagnostic == nil || out.Diagnostic.FailureCategory == "" || len(out.Recommendations) == 0 {
+		t.Fatalf("expected diagnostic output, got %+v %+v", out.Diagnostic, out.Recommendations)
+	}
+}
+
+func TestAcceptanceGitLabAC2DiagnoseFailureMapsLogUnavailable(t *testing.T) {
+	deps := newAcceptanceDependenciesWithAdapters(
+		t,
+		[]providers.Adapter{
+			githubapi.NewProviderAdapter(&acceptanceGitHubClient{}, "https://api.github.com"),
+			gitlabapi.NewProviderAdapter(&acceptanceGitLabClient{
+				getPipelineFn: func(context.Context, string, int64) (*gitlabapi.Pipeline, error) {
+					return &gitlabapi.Pipeline{ID: 55, Name: "ci", WebURL: "https://gitlab.example.com/group/app/-/pipelines/55"}, nil
+				},
+				listPipelineJobsFn: func(context.Context, string, int64) ([]gitlabapi.Job, error) {
+					return []gitlabapi.Job{{ID: 4, Name: "test", Status: "failed"}}, nil
+				},
+				downloadJobTraceFn: func(context.Context, string, int64, int64) (string, error) {
+					return "", gitlabapi.ErrLogsUnavailable
+				},
+			}, "https://gitlab.example.com/api/v4"),
+		},
+		&acceptanceAuditStore{},
+		true,
+	)
+
+	_, out, err := deps.diagnoseFailure(context.Background(), nil, DiagnoseFailureInput{
+		Provider:   "gitlab_ci",
+		Repository: "group/app",
+		RunID:      55,
+	})
+	if err != nil {
+		t.Fatalf("diagnoseFailure() error = %v", err)
+	}
+	if out.Error == nil || out.Error.Code != domain.ErrorCodeLogUnavailable {
+		t.Fatalf("expected LOG_UNAVAILABLE, got %+v", out.Error)
+	}
+}
+
+func TestAcceptanceGitLabAC3AnalyzeFlakyTestsReturnsFrequencyRecencyConfidence(t *testing.T) {
+	now := time.Date(2026, 3, 6, 12, 0, 0, 0, time.UTC)
+	deps := newAcceptanceDependenciesWithAdapters(
+		t,
+		[]providers.Adapter{
+			githubapi.NewProviderAdapter(&acceptanceGitHubClient{}, "https://api.github.com"),
+			gitlabapi.NewProviderAdapter(&acceptanceGitLabClient{
+				listPipelinesFn: func(context.Context, string, gitlabapi.ListPipelinesOptions, int) ([]gitlabapi.Pipeline, error) {
+					return []gitlabapi.Pipeline{
+						{ID: 1, Name: "ci", Status: "failed", UpdatedAt: now.Add(-2 * time.Hour)},
+						{ID: 2, Name: "ci", Status: "failed", UpdatedAt: now.Add(-1 * time.Hour)},
+						{ID: 3, Name: "ci", Status: "success", UpdatedAt: now.Add(-30 * time.Minute)},
+					}, nil
+				},
+				listPipelineJobsFn: func(context.Context, string, int64) ([]gitlabapi.Job, error) {
+					return []gitlabapi.Job{{ID: 5, Name: "test", Status: "failed"}}, nil
+				},
+				downloadJobTraceFn: func(_ context.Context, _ string, jobID int64, _ int64) (string, error) {
+					if jobID == 5 {
+						return "--- FAIL: TestCheckout", nil
+					}
+					return "", nil
+				},
+			}, "https://gitlab.example.com/api/v4"),
+		},
+		&acceptanceAuditStore{},
+		true,
+	)
+
+	_, out, err := deps.analyzeFlakyTests(context.Background(), nil, AnalyzeFlakyTestsInput{
+		Provider:     "gitlab_ci",
+		Repository:   "group/app",
+		LookbackDays: 14,
+	})
+	if err != nil {
+		t.Fatalf("analyzeFlakyTests() error = %v", err)
+	}
+	if out.Error != nil {
+		t.Fatalf("unexpected tool error: %+v", out.Error)
+	}
+	if out.Report == nil || len(out.Report.TopFlaky) == 0 {
+		t.Fatalf("expected flaky report, got %+v", out.Report)
+	}
+}
+
+func TestAcceptanceGitLabAC4RerunSupportsFailedJobsOnlyAndRejectsFullRun(t *testing.T) {
+	auditStore := &acceptanceAuditStore{}
+	deps := newAcceptanceDependenciesWithAdapters(
+		t,
+		[]providers.Adapter{
+			githubapi.NewProviderAdapter(&acceptanceGitHubClient{}, "https://api.github.com"),
+			gitlabapi.NewProviderAdapter(&acceptanceGitLabClient{
+				retryPipelineFn: func(context.Context, string, int64) error { return nil },
+			}, "https://gitlab.example.com/api/v4"),
+		},
+		auditStore,
+		false,
+	)
+
+	_, invalid, err := deps.rerun(context.Background(), nil, RerunInput{
+		Provider:       "gitlab_ci",
+		Repository:     "group/app",
+		RunID:          99,
+		FailedJobsOnly: false,
+		Reason:         "retry all jobs",
+	})
+	if err != nil {
+		t.Fatalf("rerun() validation error = %v", err)
+	}
+	if invalid.Error == nil || invalid.Error.Code != domain.ErrorCodeInvalidInput {
+		t.Fatalf("expected INVALID_INPUT, got %+v", invalid.Error)
+	}
+
+	_, out, err := deps.rerun(context.Background(), nil, RerunInput{
+		Provider:       "gitlab_ci",
+		Repository:     "group/app",
+		RunID:          99,
+		FailedJobsOnly: true,
+		Reason:         "retry failed jobs",
+	})
+	if err != nil {
+		t.Fatalf("rerun() error = %v", err)
+	}
+	if out.Error != nil {
+		t.Fatalf("unexpected tool error: %+v", out.Error)
+	}
+	if out.Result == nil || out.Result.Scope != "failed_jobs_only" {
+		t.Fatalf("expected rerun scope failed_jobs_only, got %+v", out.Result)
+	}
+	if len(auditStore.events) != 2 {
+		t.Fatalf("expected 2 audit events, got %d", len(auditStore.events))
+	}
+}
+
+func TestAcceptanceGitLabAC5ComparePerformanceReturnsBaselineCurrentAndFailureBreakdown(t *testing.T) {
+	from := time.Date(2026, 3, 6, 11, 0, 0, 0, time.UTC)
+	to := time.Date(2026, 3, 6, 12, 0, 0, 0, time.UTC)
+	deps := newAcceptanceDependenciesWithAdapters(
+		t,
+		[]providers.Adapter{
+			githubapi.NewProviderAdapter(&acceptanceGitHubClient{}, "https://api.github.com"),
+			gitlabapi.NewProviderAdapter(&acceptanceGitLabClient{
+				listPipelinesFn: func(_ context.Context, _ string, opts gitlabapi.ListPipelinesOptions, _ int) ([]gitlabapi.Pipeline, error) {
+					switch {
+					case opts.CreatedAfter == "2026-03-06T11:00:00Z" && opts.CreatedBefore == "2026-03-06T12:00:00Z":
+						currentStart := from.Add(5 * time.Minute)
+						currentEnd := to.Add(-10 * time.Minute)
+						failedStart := from.Add(10 * time.Minute)
+						failedEnd := to.Add(-5 * time.Minute)
+						return []gitlabapi.Pipeline{
+							{ID: 2, Name: "ci", Status: "success", CreatedAt: from, StartedAt: &currentStart, FinishedAt: &currentEnd, UpdatedAt: currentEnd, SHA: "sha-2"},
+							{ID: 3, Name: "ci", Status: "failed", CreatedAt: from.Add(2 * time.Minute), StartedAt: &failedStart, FinishedAt: &failedEnd, UpdatedAt: failedEnd, SHA: "sha-3"},
+						}, nil
+					case opts.CreatedAfter == "2026-03-06T10:00:00Z" && opts.CreatedBefore == "2026-03-06T11:00:00Z":
+						baselineStart := from.Add(-55 * time.Minute)
+						baselineEnd := from.Add(-15 * time.Minute)
+						return []gitlabapi.Pipeline{
+							{ID: 1, Name: "ci", Status: "failed", CreatedAt: from.Add(-60 * time.Minute), StartedAt: &baselineStart, FinishedAt: &baselineEnd, UpdatedAt: baselineEnd, SHA: "sha-1"},
+						}, nil
+					default:
+						t.Fatalf("unexpected created range after=%s before=%s", opts.CreatedAfter, opts.CreatedBefore)
+						return nil, nil
+					}
+				},
+			}, "https://gitlab.example.com/api/v4"),
+		},
+		&acceptanceAuditStore{},
+		true,
+	)
+
+	_, out, err := deps.comparePerformance(context.Background(), nil, ComparePerformanceInput{
+		Provider:   "gitlab_ci",
+		Repository: "group/app",
+		Workflow:   "ci",
+		From:       from.Format(time.RFC3339),
+		To:         to.Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("comparePerformance() error = %v", err)
+	}
+	if out.Error != nil || out.Snapshot == nil {
+		t.Fatalf("expected performance snapshot, got error=%+v snapshot=%+v", out.Error, out.Snapshot)
+	}
+}
+
 func newAcceptanceDependencies(t *testing.T, client *acceptanceGitHubClient, auditStore *acceptanceAuditStore, disableMutations bool) Dependencies {
+	t.Helper()
+
+	return newAcceptanceDependenciesWithAdapters(t, []providers.Adapter{githubapi.NewProviderAdapter(client, "https://api.github.com")}, auditStore, disableMutations)
+}
+
+func newAcceptanceDependenciesWithAdapters(t *testing.T, adapters []providers.Adapter, auditStore *acceptanceAuditStore, disableMutations bool) Dependencies {
 	t.Helper()
 
 	collector := telemetry.NewCollector("")
@@ -302,6 +568,7 @@ func newAcceptanceDependencies(t *testing.T, client *acceptanceGitHubClient, aud
 		ServerName:          "pipeline-mcp",
 		Version:             "test",
 		GitHubAPIBaseURL:    "https://api.github.com",
+		GitLabAPIBaseURL:    "https://gitlab.com/api/v4",
 		DisableMutations:    disableMutations,
 		MaxLogBytes:         20 * 1024 * 1024,
 		DefaultLookbackDays: 14,
@@ -310,16 +577,16 @@ func newAcceptanceDependencies(t *testing.T, client *acceptanceGitHubClient, aud
 	}
 
 	return Dependencies{
-		Service:   service.New(cfg, mustAcceptanceRegistry(t, githubapi.NewProviderAdapter(client, cfg.GitHubAPIBaseURL)), auditStore, collector, logger),
+		Service:   service.New(cfg, mustAcceptanceRegistry(t, adapters...), auditStore, collector, logger),
 		Telemetry: collector,
 		Logger:    logger,
 	}
 }
 
-func mustAcceptanceRegistry(t *testing.T, adapter providers.Adapter) *providers.Registry {
+func mustAcceptanceRegistry(t *testing.T, adapters ...providers.Adapter) *providers.Registry {
 	t.Helper()
 
-	registry, err := providers.NewRegistry(adapter.ProviderID(), adapter)
+	registry, err := providers.NewRegistry(adapters[0].ProviderID(), adapters...)
 	if err != nil {
 		t.Fatalf("providers.NewRegistry() error = %v", err)
 	}


### PR DESCRIPTION
## Summary
- implement slices 15-17 of the post-MVP plan by adding a GitLab CI provider alongside GitHub Actions
- add GitLab runtime config, client/adapter logic, read-tool parity, and failed-job-only rerun support with shared error mapping
- extend service, acceptance, and provider tests; update operator and release docs for GitLab scopes and rerun limits

## Linked slices
- #12
- #13
- #14

## Test command output
- `GOCACHE=$(pwd)/.gocache go test ./...` ✅
- `GOCACHE=$(pwd)/.gocache go build ./...` ✅

## Config impact
- adds `GITLAB_API_BASE_URL` (default `https://gitlab.com/api/v4`)
- adds `GITLAB_READ_TOKEN` for GitLab read tools
- adds `GITLAB_WRITE_TOKEN` for `pipeline.rerun` when `provider="gitlab_ci"`
- changes mutation startup behavior so `DISABLE_MUTATIONS=false` no longer requires `GITHUB_WRITE_TOKEN`; rerun auth is enforced per provider

## Sample request
```json
{
  "provider": "gitlab_ci",
  "repository": "group/subgroup/project",
  "run_id": 12345
}
```

## Sample response
```json
{
  "run": {
    "provider": "gitlab_ci",
    "repository": "group/subgroup/project",
    "workflow": "ci",
    "run_id": 12345,
    "run_url": "https://gitlab.example.com/group/subgroup/project/-/pipelines/12345"
  }
}
```